### PR TITLE
Feat/tournament series selection persistence

### DIFF
--- a/src/components/tournaments/tournament-list-client.tsx
+++ b/src/components/tournaments/tournament-list-client.tsx
@@ -1,8 +1,7 @@
 "use client";
-
 import type { TournamentWithRelations } from "@/server/api/tournament";
 import { useLocale } from "next-intl";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SeriesSelect } from "./series-select";
 import { SeriesSidebar } from "./series-sidebar";
 import { TournamentSections } from "./tournament-sections";
@@ -25,13 +24,34 @@ interface TournamentListClientProps {
   };
 }
 
+const tournamentSeriesFilterKey = "tournament-series-filter";
+
 export function TournamentListClient({
   tournaments,
   series,
   labels,
 }: TournamentListClientProps) {
-  const [selectedSeriesId, setSelectedSeriesId] = useState<string | null>(null);
   const locale = useLocale();
+
+  const [selectedSeriesId, setSelectedSeriesId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const saved = sessionStorage.getItem(tournamentSeriesFilterKey);
+
+    if (saved) {
+      setSelectedSeriesId(saved);
+    }
+  }, []);
+
+  const handleSelect = (id: string | null) => {
+    setSelectedSeriesId(id);
+
+    if (id) {
+      sessionStorage.setItem(tournamentSeriesFilterKey, id);
+    } else {
+      sessionStorage.removeItem(tournamentSeriesFilterKey);
+    }
+  };
 
   const filtered = selectedSeriesId
     ? tournaments.filter((t) => t.tournamentSeriesId === selectedSeriesId)
@@ -54,7 +74,7 @@ export function TournamentListClient({
         navLinks={navLinks}
         selectedSeriesId={selectedSeriesId}
         seriesLabel={labels.seriesLabel}
-        onSelect={setSelectedSeriesId}
+        onSelect={handleSelect}
       />
 
       <div className="panel min-w-0 flex-1">
@@ -63,7 +83,7 @@ export function TournamentListClient({
             navLinks={navLinks}
             selectedSeriesId={selectedSeriesId}
             seriesLabel={labels.seriesLabel}
-            onSelect={setSelectedSeriesId}
+            onSelect={handleSelect}
           />
           <TournamentSections
             tournaments={filtered}

--- a/src/components/tournaments/tournament-nav.tsx
+++ b/src/components/tournaments/tournament-nav.tsx
@@ -38,6 +38,7 @@ export function TournamentNav({ links }: TournamentNavProps) {
           <Link
             key={link.href}
             href={link.href}
+            replace
             className={cn(
               "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
               isActive
@@ -60,7 +61,7 @@ export function TournamentNavMobile({ links }: TournamentNavProps) {
   return (
     <Select
       value={active?.href ?? links[0]?.href}
-      onValueChange={(href) => router.push(href)}
+      onValueChange={(href) => router.replace(href)}
     >
       <SelectTrigger className="w-full">
         <SelectValue />


### PR DESCRIPTION
Navigating between TournamentNav components now doesn't append history.
- This ensures going back does not go through previously selected tournament navigation pages, but returns to tournament overview page.

Added tournament series name persistence when going back from tournament detail view; previous series filter will be applied.