### PR TITLE
Refactored group page components

### DIFF
--- a/src/app/(app)/tournaments/[seriesSlug]/[urlKey]/groups/page.tsx
+++ b/src/app/(app)/tournaments/[seriesSlug]/[urlKey]/groups/page.tsx
@@ -1,12 +1,7 @@
 import { GroupsPageContent } from "@/components/tournaments/groups/GroupsPageContent";
-import type { TournamentMatchData } from "@/components/tournaments/groups/types/types";
+import type { GroupPageData } from "@/components/tournaments/groups/types/types";
 import { getTournamentPageData } from "@/lib/helpers/tournament-page-data";
 import { api } from "@/trpc/server";
-
-interface GroupMatches {
-  groupId: string;
-  matches: TournamentMatchData;
-}
 
 export default async function TournamentGroupsPage({
   params,
@@ -18,26 +13,35 @@ export default async function TournamentGroupsPage({
 
   const groups = await api.tournaments.groups.listByTournament({
     tournamentId: section.tournamentId,
-    includeMatches: true,
     includeParticipants: true,
-    includeMatchMode: true,
   });
 
-  const matches: GroupMatches[] = [];
+  const groupData: GroupPageData[] = [];
 
   for (const g of groups) {
+    const participants = await api.tournaments.groups.getParticipants({
+      groupId: g.id,
+    });
+
     const matchesForGroup = await api.tournaments.matches.list({
       groupId: g.id,
     });
-    matches.push({ groupId: g.id, matches: matchesForGroup });
+
+    groupData.push({
+      groupId: g.id,
+      groupColor: g.color!,
+      groupName: g.name,
+      matches: matchesForGroup,
+      players: participants.map((p) => ({
+        id: p.id,
+        name: p.nickname,
+      })),
+    });
   }
 
   return (
     <div className="panel space-y-4">
-      <GroupsPageContent
-        groups={groups}
-        groupMatches={matches}
-      />
+      <GroupsPageContent groupsData={groupData} />
     </div>
   );
 }

--- a/src/components/tournaments/groups/GroupLeaderboardTable.tsx
+++ b/src/components/tournaments/groups/GroupLeaderboardTable.tsx
@@ -39,20 +39,18 @@ export function GroupLeaderboardTable({
     });
   }
 
-  for (const match of groupData.matches) {
+  const approvedMatches = groupData.matches.filter(
+    (m) => m.status === "ADMIN_APPROVED",
+  );
+
+  for (const match of approvedMatches) {
     for (const participant of match.TournamentMatchParticipant) {
       const player = playerMap.get(participant.participantId!);
 
       if (!player) continue;
 
-      if (participant.participant?.nickname) {
-        player.playerName = participant.participant.nickname;
-      }
-
-      // Only update stats for approved matches
-      if (match.status !== "ADMIN_APPROVED") continue;
-
       player.matchesPlayed++;
+
       if (participant.isWinner) {
         player.matchesWon++;
       } else {

--- a/src/components/tournaments/groups/GroupLeaderboardTable.tsx
+++ b/src/components/tournaments/groups/GroupLeaderboardTable.tsx
@@ -8,34 +8,38 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useTranslations } from "next-intl";
-import type {
-  LeaderboardPlayerStats,
-  TournamentGroup,
-  TournamentMatchData,
-} from "./types/types";
+import type { GroupPageData } from "./types/types";
 
-type Props = {
-  group: TournamentGroup;
-  matches: TournamentMatchData;
-};
+interface LeaderboardPlayerStats {
+  playerId: string;
+  playerName: string;
+  matchesPlayed: number;
+  matchesWon: number;
+  matchesLost: number;
+  totalScore: number;
+}
 
-export function GroupLeaderboardTable({ group, matches }: Props) {
+export function GroupLeaderboardTable({
+  groupData,
+}: {
+  groupData: GroupPageData;
+}) {
   const t = useTranslations("tournament.groups");
 
   const playerMap = new Map<string, LeaderboardPlayerStats>();
 
-  group.TournamentGroupParticipant.forEach((p) => {
-    playerMap.set(p.tournamentParticipantId, {
-      playerId: p.tournamentParticipantId,
-      playerName: "", // initially empty as group doesn't have this data.
+  for (const player of groupData.players) {
+    playerMap.set(player.id, {
+      playerId: player.id,
+      playerName: player.name,
       matchesPlayed: 0,
       matchesWon: 0,
       matchesLost: 0,
       totalScore: 0,
     });
-  });
+  }
 
-  for (const match of matches) {
+  for (const match of groupData.matches) {
     for (const participant of match.TournamentMatchParticipant) {
       const player = playerMap.get(participant.participantId!);
 
@@ -65,7 +69,7 @@ export function GroupLeaderboardTable({ group, matches }: Props) {
   return (
     <Card className="w-full text-center">
       <CardHeader>
-        <CardTitle>{group.name}</CardTitle>
+        <CardTitle>{groupData.groupName}</CardTitle>
       </CardHeader>
       <CardContent>
         <Table>

--- a/src/components/tournaments/groups/GroupSelectionView.tsx
+++ b/src/components/tournaments/groups/GroupSelectionView.tsx
@@ -3,37 +3,37 @@
 import { Button } from "@/components/ui";
 import { Card } from "@/components/ui/card";
 import { isBrightColor } from "@/lib/utils";
-import type { TournamentGroups } from "./types/types";
+import type { GroupPageData } from "./types/types";
 
 type Props = {
-  groups: TournamentGroups;
+  groupsData: GroupPageData[];
   selectedGroup: string | null;
   onSelectGroup: (group: string) => void;
 };
 
 export function GroupSelectionView({
-  groups,
+  groupsData,
   selectedGroup,
   onSelectGroup,
 }: Props) {
   return (
     <Card className="flex w-full flex-row flex-wrap items-center justify-center gap-2">
-      {groups.map((g) => {
-        const color = g.color!;
+      {groupsData.map((g) => {
+        const color = g.groupColor;
         const labelColor = isBrightColor(color) ? "#000" : "#fff";
 
         return (
           <Button
-            key={g.id}
+            key={g.groupId}
             className={`text-md p-5 font-bold ${
-              g.id === selectedGroup ? "ring-2 ring-stone-300" : ""
+              g.groupId === selectedGroup ? "ring-2 ring-stone-300" : ""
             } hover:ring-2 hover:ring-stone-300`}
             style={
               color ? { backgroundColor: color, color: labelColor } : undefined
             }
-            onClick={() => onSelectGroup(g.id)}
+            onClick={() => onSelectGroup(g.groupId)}
           >
-            {g.name}
+            {g.groupName}
           </Button>
         );
       })}

--- a/src/components/tournaments/groups/GroupsPageContent.tsx
+++ b/src/components/tournaments/groups/GroupsPageContent.tsx
@@ -4,24 +4,19 @@ import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { GroupLeaderboardTable } from "./GroupLeaderboardTable";
 import { GroupSelectionView } from "./GroupSelectionView";
-import type { GroupMatches, TournamentGroups } from "./types/types";
+import type { GroupPageData } from "./types/types";
 
-type Props = {
-  groups: TournamentGroups;
-  groupMatches: GroupMatches[];
-};
-
-export function GroupsPageContent({ groups, groupMatches }: Props) {
+export function GroupsPageContent({
+  groupsData,
+}: {
+  groupsData: GroupPageData[];
+}) {
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
-
   const t = useTranslations("tournament.groups");
 
-  const selectedGroupData = groups.find((g) => g.id === selectedGroup);
+  const selectedGroupData = groupsData.find((g) => g.groupId === selectedGroup);
 
-  const groupMatchData =
-    groupMatches.find((m) => m.groupId === selectedGroup) ?? null;
-
-  if (groups.length === 0) {
+  if (groupsData.length === 0) {
     return (
       <div className="flex w-full flex-col items-center justify-center gap-4 py-10">
         <h2 className="text-lg font-bold">{t("no_groups")}</h2>
@@ -32,15 +27,12 @@ export function GroupsPageContent({ groups, groupMatches }: Props) {
   return (
     <>
       <GroupSelectionView
-        groups={groups}
+        groupsData={groupsData}
         selectedGroup={selectedGroup}
         onSelectGroup={setSelectedGroup}
       />
-      {selectedGroupData && groupMatchData?.matches.length && (
-        <GroupLeaderboardTable
-          group={selectedGroupData}
-          matches={groupMatchData.matches}
-        />
+      {selectedGroupData && (
+        <GroupLeaderboardTable groupData={selectedGroupData} />
       )}
     </>
   );

--- a/src/components/tournaments/groups/types/types.ts
+++ b/src/components/tournaments/groups/types/types.ts
@@ -1,28 +1,17 @@
 import type { AppRouter } from "@/server/api/root";
 import type { inferProcedureOutput } from "@trpc/server";
 
-export type TournamentGroup = inferProcedureOutput<
-  AppRouter["tournaments"]["groups"]["listByTournament"]
->[number];
-
-export type TournamentGroups = inferProcedureOutput<
-  AppRouter["tournaments"]["groups"]["listByTournament"]
->;
-
-export type TournamentMatchData = inferProcedureOutput<
+type TournamentMatchData = inferProcedureOutput<
   AppRouter["tournaments"]["matches"]["list"]
 >;
 
-export interface GroupMatches {
+export interface GroupPageData {
   groupId: string;
+  groupColor: string;
+  groupName: string;
   matches: TournamentMatchData;
-}
-
-export interface LeaderboardPlayerStats {
-  playerId: string;
-  playerName: string;
-  matchesPlayed: number;
-  matchesWon: number;
-  matchesLost: number;
-  totalScore: number;
+  players: {
+    id: string;
+    name: string;
+  }[];
 }


### PR DESCRIPTION
- Easier to maintain - passing around simple object that contains required data. 
- Ensured player names are always supplied, as before they were taken from match data, fixing issue where pages with no matches would render incorrectly.
- Removed no longer used types.