### PR TITLE
Registration extra fields

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -240,6 +240,37 @@
           "removed": "Section {name} deleted.",
           "created": "Section created.",
           "predefined_created": "{count, plural, one {Added # section.} other {Added # sections.}}"
+        },
+        "registration": {
+          "fields_description": "Define additional fields that participants must fill out when registering.",
+          "no_fields": "No registration fields defined.",
+          "add_field": "Add field",
+          "save": "Save",
+          "cancel": "Cancel",
+          "remove": "Remove",
+          "required_badge": "Required",
+          "field_label": "Label",
+          "field_label_placeholder": "e.g. AoE2Companion URL",
+          "field_type_label": "Type",
+          "field_required": "Required",
+          "field_type": {
+            "string": "Text",
+            "number": "Number",
+            "boolean": "Yes / No"
+          },
+          "dialog": {
+            "create_title": "Add registration field",
+            "edit_title": "Edit registration field"
+          },
+          "confirm_delete": {
+            "title": "Delete field",
+            "description": "Are you sure you want to delete the field \"{label}\"? Existing answers will remain stored but will no longer be displayed."
+          },
+          "toast": {
+            "field_created": "Field added.",
+            "field_saved": "Field saved.",
+            "field_removed": "Field \"{label}\" removed."
+          }
         }
       },
       "participant_details": {
@@ -258,7 +289,6 @@
         "delete_cancel": "Cancel"
       }
     },
-
     "settings": {
       "title": "Settings",
       "page_title": "Admin settings",
@@ -536,7 +566,10 @@
       "register": "Register",
       "registering": "Registering...",
       "register_success": "You have successfully registered for the tournament.",
-      "must_be_logged_in": "You must be logged in to register for the tournament."
+      "must_be_logged_in": "You must be logged in to register for the tournament.",
+      "field_required_error": "This field is required.",
+      "field_number_error": "This field must be a valid number.",
+      "field_text_max_length_error": "Maximum 60 characters reached."
     },
     "detail": {
       "not_found": "Tournament not found.",
@@ -591,7 +624,6 @@
       }
     }
   },
-
   "tournament": {
     "calendar": {
       "today": "Today",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -240,6 +240,37 @@
           "removed": "Sekcja {name} usunięta.",
           "created": "Sekcja utworzona.",
           "predefined_created": "{count, plural, one {Dodano # sekcję.} few {Dodano # sekcje.} other {Dodano # sekcji.}}"
+        },
+        "registration": {
+          "fields_description": "Dodatkowe pola, które uczestnicy muszą wypełnić podczas rejestracji.",
+          "no_fields": "Brak zdefiniowanych pól rejestracji.",
+          "add_field": "Dodaj pole",
+          "save": "Zapisz",
+          "cancel": "Anuluj",
+          "remove": "Usuń",
+          "required_badge": "Wymagane",
+          "field_label": "Etykieta",
+          "field_label_placeholder": "np. link do profilu AoE2Companion",
+          "field_type_label": "Typ",
+          "field_required": "Wymagane",
+          "field_type": {
+            "string": "Tekst",
+            "number": "Liczba",
+            "boolean": "Tak / Nie"
+          },
+          "dialog": {
+            "create_title": "Dodaj pole rejestracji",
+            "edit_title": "Edytuj pole rejestracji"
+          },
+          "confirm_delete": {
+            "title": "Usuń pole",
+            "description": "Czy na pewno chcesz usunąć pole \"{label}\"? Istniejące odpowiedzi pozostaną zapisane, ale nie będą wyświetlane."
+          },
+          "toast": {
+            "field_created": "Pole dodane.",
+            "field_saved": "Pole zapisane.",
+            "field_removed": "Pole \"{label}\" usunięte."
+          }
         }
       },
       "participant_details": {
@@ -535,7 +566,10 @@
       "register": "Zarejestruj się",
       "registering": "Rejestrowanie...",
       "register_success": "Pomyślnie zarejestrowano na turniej.",
-      "must_be_logged_in": "Musisz być zalogowany, aby zarejestrować się na turniej."
+      "must_be_logged_in": "Musisz być zalogowany, aby zarejestrować się na turniej.",
+      "field_required_error": "To pole jest wymagane.",
+      "field_number_error": "To pole musi być prawidłową liczbą.",
+      "field_text_max_length_error": "Osiągnięto limit 60 znaków."
     },
     "detail": {
       "not_found": "Nie znaleziono turnieju.",

--- a/prisma/migrations/20260511105550_add_registration_fields/migration.sql
+++ b/prisma/migrations/20260511105550_add_registration_fields/migration.sql
@@ -1,0 +1,23 @@
+-- CreateEnum
+CREATE TYPE "RegistrationFieldType" AS ENUM ('STRING', 'NUMBER', 'BOOLEAN');
+
+-- AlterTable
+ALTER TABLE "TournamentParticipant" ADD COLUMN     "registrationData" JSONB;
+
+-- CreateTable
+CREATE TABLE "TournamentRegistrationField" (
+    "id" TEXT NOT NULL,
+    "tournamentId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "type" "RegistrationFieldType" NOT NULL,
+    "required" BOOLEAN NOT NULL DEFAULT false,
+    "displayOrder" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "TournamentRegistrationField_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TournamentRegistrationField_tournamentId_idx" ON "TournamentRegistrationField"("tournamentId");
+
+-- AddForeignKey
+ALTER TABLE "TournamentRegistrationField" ADD CONSTRAINT "TournamentRegistrationField_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "Tournament"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260511111950_add_registration_field_translations/migration.sql
+++ b/prisma/migrations/20260511111950_add_registration_field_translations/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `label` on the `TournamentRegistrationField` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "TournamentRegistrationField" DROP COLUMN "label";
+
+-- CreateTable
+CREATE TABLE "TournamentRegistrationFieldTranslation" (
+    "id" TEXT NOT NULL,
+    "fieldId" TEXT NOT NULL,
+    "locale" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+
+    CONSTRAINT "TournamentRegistrationFieldTranslation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TournamentRegistrationFieldTranslation_fieldId_locale_key" ON "TournamentRegistrationFieldTranslation"("fieldId", "locale");
+
+-- AddForeignKey
+ALTER TABLE "TournamentRegistrationFieldTranslation" ADD CONSTRAINT "TournamentRegistrationFieldTranslation_fieldId_fkey" FOREIGN KEY ("fieldId") REFERENCES "TournamentRegistrationField"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -203,10 +203,11 @@ model Tournament {
   name                  String
   matchMode             TournamentMatchMode     @relation(fields: [matchModeId], references: [id])
   tournamentSeries      TournamentSeries        @relation(fields: [tournamentSeriesId], references: [id])
-  TournamentParticipant TournamentParticipant[]
-  sections              TournamentSection[]
-  stages                TournamentStage[]
-  teams                 TournamentTeam[]
+  TournamentParticipant    TournamentParticipant[]
+  sections                 TournamentSection[]
+  stages                   TournamentStage[]
+  teams                    TournamentTeam[]
+  registrationFields       TournamentRegistrationField[]
 
   @@unique([tournamentSeriesId, urlKey])
 }
@@ -320,6 +321,28 @@ model TournamentGroup {
   @@unique([stageId, name])
 }
 
+model TournamentRegistrationField {
+  id           String                                   @id @default(cuid())
+  tournamentId String
+  type         RegistrationFieldType
+  required     Boolean                                  @default(false)
+  displayOrder Int                                      @default(0)
+  tournament   Tournament                               @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  translations TournamentRegistrationFieldTranslation[]
+
+  @@index([tournamentId])
+}
+
+model TournamentRegistrationFieldTranslation {
+  id      String                      @id @default(cuid())
+  fieldId String
+  locale  String
+  label   String
+  field   TournamentRegistrationField @relation(fields: [fieldId], references: [id], onDelete: Cascade)
+
+  @@unique([fieldId, locale])
+}
+
 model TournamentParticipant {
   id                         String                       @id @default(cuid())
   tournamentId               String
@@ -329,6 +352,7 @@ model TournamentParticipant {
   seedNumber                 Int?
   registrationDate           DateTime                     @default(now())
   nickname                   String
+  registrationData           Json?
   TournamentGroupParticipant TournamentGroupParticipant[]
   TournamentMatchParticipant TournamentMatchParticipant[]
   team                       TournamentTeam?              @relation(fields: [teamId], references: [id])
@@ -422,6 +446,12 @@ model Game {
   map          Map               @relation(fields: [mapId], references: [id])
   match        TournamentMatch   @relation(fields: [matchId], references: [id], onDelete: Cascade)
   participants GameParticipant[]
+}
+
+enum RegistrationFieldType {
+  STRING
+  NUMBER
+  BOOLEAN
 }
 
 enum RoleType {

--- a/src/app/(app)/tournaments/[seriesSlug]/[urlKey]/registration/page.tsx
+++ b/src/app/(app)/tournaments/[seriesSlug]/[urlKey]/registration/page.tsx
@@ -29,7 +29,7 @@ export default async function TournamentRegistrationPage({
     : null;
 
   return (
-    <div className="space-y-4">
+    <div className="panel space-y-4">
       {content && <TournamentSectionContent content={content} />}
 
       <RegistrationPanel

--- a/src/components/tournaments/registration/registration-panel.tsx
+++ b/src/components/tournaments/registration/registration-panel.tsx
@@ -68,7 +68,7 @@ export function RegistrationPanel({
     for (const field of fields) {
       const val = formData[field.id];
 
-      if (field.required && (val === undefined || val === null || val === "")) {
+      if (field.required && (val == null || val === "")) {
         newErrors[field.id] = t("field_required_error");
       } else if (
         field.type === "NUMBER" &&

--- a/src/components/tournaments/registration/registration-panel.tsx
+++ b/src/components/tournaments/registration/registration-panel.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { api } from "@/trpc/react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
 
 interface RegistrationPanelProps {
@@ -17,7 +20,18 @@ export function RegistrationPanel({
   isAlreadyRegistered,
 }: RegistrationPanelProps) {
   const t = useTranslations("tournaments.registration");
+  const locale = useLocale();
   const [registered, setRegistered] = useState(false);
+  const [formData, setFormData] = useState<
+    Record<string, string | number | boolean>
+  >({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const { data: fields = [] } =
+    api.tournaments.registrationFields.list.useQuery(
+      { tournamentId },
+      { enabled: isLoggedIn && !isAlreadyRegistered },
+    );
 
   const { mutate: register, isPending } =
     api.tournaments.participants.register.useMutation({
@@ -48,12 +62,133 @@ export function RegistrationPanel({
     );
   }
 
+  function validate() {
+    const newErrors: Record<string, string> = {};
+
+    for (const field of fields) {
+      const val = formData[field.id];
+
+      if (field.required && (val === undefined || val === null || val === "")) {
+        newErrors[field.id] = t("field_required_error");
+      } else if (
+        field.type === "NUMBER" &&
+        val !== undefined &&
+        val !== "" &&
+        isNaN(Number(val))
+      ) {
+        newErrors[field.id] = t("field_number_error");
+      }
+    }
+
+    setErrors(newErrors);
+
+    return Object.keys(newErrors).length === 0;
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+    register({ tournamentId, formData });
+  }
+
   return (
-    <Button
-      onClick={() => register({ tournamentId })}
-      disabled={isPending}
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4"
     >
-      {isPending ? t("registering") : t("register")}
-    </Button>
+      {fields.map((field) => {
+        const fieldLabel =
+          field.translations.find((tr) => tr.locale === locale)?.label ?? "";
+
+        return (
+          <div
+            key={field.id}
+            className="space-y-1"
+          >
+            <Label htmlFor={`reg-${field.id}`}>
+              {fieldLabel}
+              {field.required && (
+                <span className="text-destructive ml-1">*</span>
+              )}
+            </Label>
+
+            <FieldInput
+              field={field}
+              value={formData[field.id]}
+              onChange={(value) => {
+                setFormData((prev) => ({ ...prev, [field.id]: value }));
+
+                if (value.toString().length >= 60) {
+                  setErrors((prev) => ({
+                    ...prev,
+                    [field.id]: t("field_text_max_length_error"),
+                  }));
+                } else if (errors[field.id]) {
+                  setErrors((prev) => {
+                    const next = { ...prev };
+                    delete next[field.id];
+                    return next;
+                  });
+                }
+              }}
+            />
+
+            {errors[field.id] && (
+              <p className="text-destructive text-sm">{errors[field.id]}</p>
+            )}
+          </div>
+        );
+      })}
+
+      <Button
+        type="submit"
+        disabled={isPending}
+      >
+        {isPending ? t("registering") : t("register")}
+      </Button>
+    </form>
+  );
+}
+
+function FieldInput({
+  field,
+  value,
+  onChange,
+}: {
+  field: { id: string; type: string };
+  value: string | number | boolean | undefined;
+  onChange: (value: string | number | boolean) => void;
+}) {
+  if (field.type === "BOOLEAN") {
+    return (
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id={`reg-${field.id}`}
+          checked={!!value}
+          onCheckedChange={(v) => onChange(!!v)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <Input
+      id={`reg-${field.id}`}
+      type={field.type === "NUMBER" ? "number" : "text"}
+      maxLength={field.type === "STRING" ? 60 : undefined}
+      value={!!value ? String(value) : ""}
+      onChange={(e) => {
+        const raw = e.target.value;
+
+        if (field.type === "NUMBER" && raw !== "" && isNaN(Number(raw))) {
+          return;
+        }
+
+        const parsed =
+          field.type === "NUMBER" && raw !== "" ? Number(raw) : raw;
+
+        onChange(parsed);
+      }}
+    />
   );
 }

--- a/src/lib/admin-panel/tournaments/participant-data-dialog.tsx
+++ b/src/lib/admin-panel/tournaments/participant-data-dialog.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { api } from "@/trpc/react";
+import type {
+  TournamentRegistrationField,
+  TournamentRegistrationFieldTranslation,
+} from "@prisma/client";
+import { ClipboardList } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+type RegistrationFieldWithTranslations = TournamentRegistrationField & {
+  translations: TournamentRegistrationFieldTranslation[];
+};
+
+type ParticipantDataDialogProps = {
+  participantId: string;
+  registrationData: Record<string, unknown>;
+  registrationFields: RegistrationFieldWithTranslations[];
+  locale: string;
+};
+
+// Dialog to use in admin panel, to view/edit participants registration data.
+export function ParticipantDataDialog({
+  participantId,
+  registrationData,
+  registrationFields,
+  locale,
+}: ParticipantDataDialogProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState<Record<string, string | number | boolean>>(
+    () =>
+      Object.fromEntries(
+        registrationFields.map((field): [string, string | number | boolean] => {
+          const val = registrationData[field.id];
+
+          if (field.type === "BOOLEAN") {
+            return [field.id, !!val];
+          }
+
+          if (field.type === "NUMBER") {
+            return [field.id, Number(val)];
+          }
+
+          return [field.id, String(val)];
+        }),
+      ),
+  );
+
+  const { mutate: save, isPending } =
+    api.tournaments.participants.updateRegistrationData.useMutation({
+      onSuccess: () => {
+        toast.success("Registration data updated");
+        setOpen(false);
+        router.refresh();
+      },
+      onError: () => {
+        toast.error("Failed to update registration data");
+      },
+    });
+
+  function getLabel(field: RegistrationFieldWithTranslations): string {
+    return (
+      field.translations.find((tr) => tr.locale === locale)?.label ??
+      "Missing label!"
+    );
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+        >
+          <ClipboardList className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Registration Data</DialogTitle>
+        </DialogHeader>
+        {registrationFields.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No registration fields.
+          </p>
+        ) : (
+          <div className="space-y-4 py-2">
+            {registrationFields.map((field) => (
+              <div
+                key={field.id}
+                className="grid grid-cols-2 items-center gap-4"
+              >
+                <span className="text-sm font-medium">{getLabel(field)}</span>
+                {field.type === "BOOLEAN" ? (
+                  <Switch
+                    checked={data[field.id] as boolean}
+                    onCheckedChange={(checked) =>
+                      setData((prev) => ({ ...prev, [field.id]: checked }))
+                    }
+                  />
+                ) : (
+                  <Input
+                    type={field.type === "NUMBER" ? "number" : "text"}
+                    value={data[field.id] as string}
+                    onChange={(e) =>
+                      setData((prev) => ({
+                        ...prev,
+                        [field.id]:
+                          field.type === "NUMBER"
+                            ? e.target.value === ""
+                              ? ""
+                              : Number(e.target.value)
+                            : e.target.value,
+                      }))
+                    }
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+        <DialogFooter>
+          <Button
+            onClick={() => save({ participantId, registrationData: data })}
+            disabled={isPending}
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/admin-panel/tournaments/sections/registration/registration-field-dialog.tsx
+++ b/src/lib/admin-panel/tournaments/sections/registration/registration-field-dialog.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { ErrorToast } from "@/components/ui/error-toast-content";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { locales, type Locale } from "@/lib/locales";
+import { api } from "@/trpc/react";
+import type {
+  TournamentRegistrationField,
+  TournamentRegistrationFieldTranslation,
+} from "@prisma/client";
+import { RegistrationFieldType } from "@prisma/client";
+import { PlusIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+type FieldWithTranslations = TournamentRegistrationField & {
+  translations: TournamentRegistrationFieldTranslation[];
+};
+
+interface RegistrationFieldDialogProps {
+  tournamentId: string;
+  field?: FieldWithTranslations;
+  nextDisplayOrder?: number;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onSaved: () => void;
+  trigger?: React.ReactNode;
+}
+
+export function RegistrationFieldDialog({
+  tournamentId,
+  field,
+  nextDisplayOrder = 0,
+  open: openProp,
+  onOpenChange: onOpenChangeProp,
+  onSaved,
+  trigger,
+}: RegistrationFieldDialogProps) {
+  const t = useTranslations("admin.tournaments.sections.registration");
+
+  const [openInternal, setOpenInternal] = useState(false);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : openInternal;
+
+  function setOpen(v: boolean) {
+    if (isControlled) onOpenChangeProp?.(v);
+    else setOpenInternal(v);
+  }
+
+  const [required, setRequired] = useState(false);
+  const [activeLocale, setActiveLocale] = useState<Locale>(locales.default);
+
+  const [labels, setLabels] = useState<Record<string, string>>(() =>
+    Object.fromEntries(locales.supported.map((l) => [l, ""])),
+  );
+
+  const [type, setType] = useState<RegistrationFieldType>(
+    RegistrationFieldType.STRING,
+  );
+
+  useEffect(() => {
+    if (!open) return;
+
+    setActiveLocale(locales.default);
+    setType(field?.type ?? RegistrationFieldType.STRING);
+    setRequired(field?.required ?? false);
+    setLabels(
+      Object.fromEntries(
+        locales.supported.map((l) => [
+          l,
+          field?.translations.find((tr) => tr.locale === l)?.label ?? "",
+        ]),
+      ),
+    );
+  }, [open, field]);
+
+  const { mutate: createField, isPending: createPending } =
+    api.tournaments.registrationFields.create.useMutation({
+      onSuccess: () => {
+        toast.success(t("toast.field_created"));
+        onSaved();
+        setOpen(false);
+      },
+      onError: (error) => toast.error(<ErrorToast message={error.message} />),
+    });
+
+  const { mutate: updateField, isPending: updatePending } =
+    api.tournaments.registrationFields.update.useMutation({
+      onSuccess: () => {
+        toast.success(t("toast.field_saved"));
+        onSaved();
+        setOpen(false);
+      },
+      onError: (error) => toast.error(<ErrorToast message={error.message} />),
+    });
+
+  const isPending = createPending || updatePending;
+
+  const translations = locales.supported.map((l) => ({
+    locale: l,
+    label: labels[l] ?? "",
+  }));
+
+  const defaultLabel = labels[locales.default] ?? "";
+  const isValid = defaultLabel.trim().length > 0;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isValid) return;
+    if (field) {
+      updateField({ id: field.id, translations, type, required });
+    } else {
+      createField({
+        tournamentId,
+        translations,
+        type,
+        required,
+        displayOrder: nextDisplayOrder,
+      });
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <DialogTrigger asChild>
+        {trigger ?? (
+          <Button
+            variant="outline"
+            size="sm"
+          >
+            <PlusIcon className="mr-2 h-4 w-4" />
+            {t("add_field")}
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {field ? t("dialog.edit_title") : t("dialog.create_title")}
+          </DialogTitle>
+        </DialogHeader>
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4 pt-2"
+        >
+          {/* Locale tabs & field labels */}
+          <div className="space-y-3">
+            <div className="flex gap-1">
+              {locales.supported.map((locale) => (
+                <Button
+                  key={locale}
+                  type="button"
+                  variant={activeLocale === locale ? "default" : "secondary"}
+                  size="sm"
+                  onClick={() => setActiveLocale(locale)}
+                >
+                  {locale.toUpperCase()}
+                </Button>
+              ))}
+            </div>
+
+            {locales.supported.map((locale) => (
+              <div
+                key={locale}
+                className={activeLocale === locale ? "" : "hidden"}
+              >
+                <Label htmlFor={`reg-label-${locale}`}>
+                  {t("field_label")}
+                  {locale === locales.default && (
+                    <span className="text-destructive ml-1">*</span>
+                  )}
+                </Label>
+                <Input
+                  id={`reg-label-${locale}`}
+                  className="mt-1"
+                  value={labels[locale] ?? ""}
+                  onChange={(e) =>
+                    setLabels((prev) => ({ ...prev, [locale]: e.target.value }))
+                  }
+                  placeholder={t("field_label_placeholder")}
+                />
+              </div>
+            ))}
+          </div>
+
+          {/* Field type */}
+          <div className="space-y-1">
+            <Label>{t("field_type_label")}</Label>
+            <Select
+              value={type}
+              onValueChange={(v) => setType(v as RegistrationFieldType)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.values(RegistrationFieldType).map((ft) => (
+                  <SelectItem
+                    key={ft}
+                    value={ft}
+                  >
+                    {t(`field_type.${ft.toLowerCase()}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Requirement checkbox */}
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="reg-field-required"
+              checked={required}
+              onCheckedChange={(v) => setRequired(!!v)}
+            />
+            <Label htmlFor="reg-field-required">{t("field_required")}</Label>
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              disabled={isPending || !isValid}
+            >
+              {field ? t("save") : t("add_field")}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/admin-panel/tournaments/sections/registration/registration-field-row.tsx
+++ b/src/lib/admin-panel/tournaments/sections/registration/registration-field-row.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { ErrorToast } from "@/components/ui/error-toast-content";
+import { api } from "@/trpc/react";
+import type {
+  TournamentRegistrationField,
+  TournamentRegistrationFieldTranslation,
+} from "@prisma/client";
+import { ArrowDown, ArrowUp, Pencil } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+type FieldWithTranslations = TournamentRegistrationField & {
+  translations: TournamentRegistrationFieldTranslation[];
+};
+
+interface RegistrationFieldRowProps {
+  field: FieldWithTranslations;
+  isFirst: boolean;
+  isLast: boolean;
+  movePending: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onEdit: () => void;
+  onSaved: () => void;
+}
+
+export function RegistrationFieldRow({
+  field,
+  isFirst,
+  isLast,
+  movePending,
+  onMoveUp,
+  onMoveDown,
+  onEdit,
+  onSaved,
+}: RegistrationFieldRowProps) {
+  const t = useTranslations("admin.tournaments.sections.registration");
+  const locale = useLocale();
+
+  const label =
+    field.translations.find((tr) => tr.locale === locale)?.label ?? "";
+
+  const { mutate: deleteField, isPending: deletePending } =
+    api.tournaments.registrationFields.delete.useMutation({
+      onSuccess: () => {
+        toast.success(t("toast.field_removed", { label }));
+        onSaved();
+      },
+      onError: (error) => toast.error(<ErrorToast message={error.message} />),
+    });
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border px-3 py-2">
+      <span className="flex-1 text-sm font-medium">{label}</span>
+      <Badge
+        variant="outline"
+        className="shrink-0 text-xs"
+      >
+        {t(`field_type.${field.type.toLowerCase()}`)}
+      </Badge>
+      {field.required && (
+        <Badge
+          variant="secondary"
+          className="shrink-0 text-xs"
+        >
+          {t("required_badge")}
+        </Badge>
+      )}
+      <div className="flex items-center gap-0.5">
+        <Button
+          variant="ghost"
+          size="icon"
+          disabled={isFirst || movePending || deletePending}
+          onClick={onMoveUp}
+        >
+          <ArrowUp className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          disabled={isLast || movePending || deletePending}
+          onClick={onMoveDown}
+        >
+          <ArrowDown className="h-4 w-4" />
+        </Button>
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        disabled={deletePending}
+        onClick={onEdit}
+      >
+        <Pencil className="h-4 w-4" />
+      </Button>
+      <ConfirmDialog
+        trigger={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-destructive hover:text-destructive"
+            disabled={deletePending}
+            type="button"
+          >
+            <span className="text-xs">✕</span>
+          </Button>
+        }
+        title={t("confirm_delete.title")}
+        description={t("confirm_delete.description", { label })}
+        cancelLabel={t("cancel")}
+        confirmLabel={t("remove")}
+        onConfirm={() => deleteField({ id: field.id })}
+      />
+    </div>
+  );
+}

--- a/src/lib/admin-panel/tournaments/sections/registration/tournament-registration-section-card.tsx
+++ b/src/lib/admin-panel/tournaments/sections/registration/tournament-registration-section-card.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { AccordionContent, AccordionItem } from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ErrorToast } from "@/components/ui/error-toast-content";
+import { Form, FormField } from "@/components/ui/form";
+import { MarkdownEditorField } from "@/components/ui/markdown-editor-field";
+import { locales, type Locale } from "@/lib/locales";
+import { api } from "@/trpc/react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type {
+  TournamentRegistrationField,
+  TournamentRegistrationFieldTranslation,
+} from "@prisma/client";
+import { Header, Trigger } from "@radix-ui/react-accordion";
+import { ArrowDown, ArrowUp, Eye, EyeOff } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { TournamentSectionDeleteButton } from "../tournament-section-delete-button";
+import {
+  updateSectionSchema,
+  type SectionRowProps,
+  type UpdateSectionSchema,
+} from "../tournament-section-types";
+import { RegistrationFieldDialog } from "./registration-field-dialog";
+import { RegistrationFieldRow } from "./registration-field-row";
+
+type FieldWithTranslations = TournamentRegistrationField & {
+  translations: TournamentRegistrationFieldTranslation[];
+};
+
+export function TournamentRegistrationSectionCard({
+  section,
+  isFirst,
+  isLast,
+  movePending,
+  onMoveUp,
+  onMoveDown,
+  onSaved,
+}: SectionRowProps) {
+  const t = useTranslations("admin.tournaments.sections");
+  const tReg = useTranslations("admin.tournaments.sections.registration");
+  const displayTitle = t(`predefined_titles.${section.slug}`);
+
+  const [activeLocale, setActiveLocale] = useState<Locale>(locales.default);
+  const [editingField, setEditingField] =
+    useState<FieldWithTranslations | null>(null);
+
+  // ── Section description form ──
+  const defaultTranslations = Object.fromEntries(
+    locales.supported.map((locale) => {
+      const tr = section.translations.find((tr) => tr.locale === locale);
+      return [
+        locale,
+        {
+          title: t(`predefined_titles.${section.slug}`),
+          content: tr?.content ?? "",
+        },
+      ];
+    }),
+  );
+
+  const form = useForm<UpdateSectionSchema>({
+    resolver: zodResolver(updateSectionSchema),
+    defaultValues: { translations: defaultTranslations },
+  });
+
+  const { mutate: updateSection, isPending: updatePending } =
+    api.tournaments.sections.update.useMutation({
+      onSuccess: () => {
+        toast.success(t("toast.saved", { name: displayTitle }));
+        onSaved();
+      },
+      onError: (error) => toast.error(<ErrorToast message={error.message} />),
+    });
+
+  function onSubmit(values: UpdateSectionSchema) {
+    updateSection({
+      id: section.id,
+      translations: Object.entries(values.translations).map(
+        ([locale, data]) => ({
+          locale,
+          title: data.title,
+          content: data.content,
+        }),
+      ),
+    });
+  }
+
+  // ── Registration fields ──
+  const { data: fields = [], refetch: refetchFields } =
+    api.tournaments.registrationFields.list.useQuery({
+      tournamentId: section.tournamentId,
+    });
+
+  const { mutate: reorderFields, isPending: reorderPending } =
+    api.tournaments.registrationFields.reorder.useMutation({
+      onError: (error) => {
+        toast.error(<ErrorToast message={error.message} />);
+        void refetchFields();
+      },
+    });
+
+  function moveField(index: number, direction: "up" | "down") {
+    const next = [...fields];
+    const swapWith = direction === "up" ? index - 1 : index + 1;
+
+    [next[index], next[swapWith]] = [next[swapWith]!, next[index]!];
+
+    const updated = next.map((f, i) => ({ ...f, displayOrder: i }));
+
+    reorderFields({
+      updates: updated.map((f) => ({ id: f.id, displayOrder: f.displayOrder })),
+    });
+  }
+
+  // ── Section header controls ──
+  const { mutate: deleteSection, isPending: deletePending } =
+    api.tournaments.sections.delete.useMutation({
+      onSuccess: () => {
+        toast.success(t("toast.removed", { name: displayTitle }));
+        onSaved();
+      },
+      onError: (error) => toast.error(<ErrorToast message={error.message} />),
+    });
+
+  const { mutate: setVisible, isPending: visibilityPending } =
+    api.tournaments.sections.update.useMutation({
+      onSuccess: () => onSaved(),
+      onError: (error) => toast.error(<ErrorToast message={error.message} />),
+    });
+
+  const headerPending = deletePending || visibilityPending;
+  const isPending = headerPending || updatePending;
+
+  return (
+    <AccordionItem
+      value={section.id}
+      className="bg-primary-foreground mb-3 rounded-lg border px-4"
+    >
+      <Header className="flex items-center">
+        <Trigger className="flex flex-1 items-center gap-2 py-4 font-medium transition-all">
+          <span className="flex-1 text-left">{displayTitle}</span>
+          <Badge
+            variant="secondary"
+            className="shrink-0"
+          >
+            {t("special_badge")}
+          </Badge>
+          <span className="text-muted-foreground">/{section.slug}</span>
+        </Trigger>
+
+        <div
+          className="flex items-center gap-0.5 pl-2"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Button
+            variant="ghost"
+            size="icon"
+            disabled={isFirst || movePending || headerPending}
+            onClick={onMoveUp}
+          >
+            <ArrowUp />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            disabled={isLast || movePending || headerPending}
+            onClick={onMoveDown}
+          >
+            <ArrowDown />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            disabled={headerPending}
+            onClick={() =>
+              setVisible({ id: section.id, isVisible: !section.isVisible })
+            }
+          >
+            {section.isVisible ? <Eye /> : <EyeOff className="opacity-50" />}
+          </Button>
+          <TournamentSectionDeleteButton
+            name={displayTitle}
+            disabled={headerPending}
+            onConfirm={() => deleteSection({ id: section.id })}
+          />
+        </div>
+      </Header>
+
+      <AccordionContent className="space-y-6 pt-2 pb-4">
+        {/* ── Section description editor ── */}
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-4"
+          >
+            <div className="flex gap-1">
+              {locales.supported.map((locale) => (
+                <Button
+                  key={locale}
+                  type="button"
+                  variant={activeLocale === locale ? "default" : "secondary"}
+                  size="sm"
+                  onClick={() => setActiveLocale(locale)}
+                >
+                  {locale.toUpperCase()}
+                </Button>
+              ))}
+            </div>
+            {locales.supported.map((locale) => (
+              <div
+                key={locale}
+                className={activeLocale === locale ? "" : "hidden"}
+              >
+                <FormField
+                  control={form.control}
+                  name={`translations.${locale}.title`}
+                  render={() => <></>}
+                />
+                <MarkdownEditorField
+                  control={form.control}
+                  name={`translations.${locale}.content`}
+                />
+              </div>
+            ))}
+            <Button
+              type="submit"
+              disabled={isPending}
+            >
+              {t("save_changes")}
+            </Button>
+          </form>
+        </Form>
+
+        {/* ── Registration fields ── */}
+        <div className="space-y-2 border-t pt-4">
+          <p className="text-muted-foreground mb-3 text-xs">
+            {tReg("fields_description")}
+          </p>
+
+          {fields.length === 0 && (
+            <p className="text-muted-foreground text-sm">{tReg("no_fields")}</p>
+          )}
+
+          {(fields as FieldWithTranslations[]).map((field, index) => (
+            <RegistrationFieldRow
+              key={field.id}
+              field={field}
+              isFirst={index === 0}
+              isLast={index === fields.length - 1}
+              movePending={reorderPending}
+              onMoveUp={() => moveField(index, "up")}
+              onMoveDown={() => moveField(index, "down")}
+              onEdit={() => setEditingField(field)}
+              onSaved={() => void refetchFields()}
+            />
+          ))}
+
+          <div className="pt-1">
+            <RegistrationFieldDialog
+              tournamentId={section.tournamentId}
+              nextDisplayOrder={fields.length}
+              onSaved={() => void refetchFields()}
+            />
+          </div>
+
+          {editingField && (
+            <RegistrationFieldDialog
+              tournamentId={section.tournamentId}
+              field={editingField}
+              open={true}
+              onOpenChange={(v) => {
+                if (!v) setEditingField(null);
+              }}
+              onSaved={() => {
+                void refetchFields();
+                setEditingField(null);
+              }}
+            />
+          )}
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  );
+}

--- a/src/lib/admin-panel/tournaments/tournament-participants.tsx
+++ b/src/lib/admin-panel/tournaments/tournament-participants.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { ParticipantDataDialog } from "@/lib/admin-panel/tournaments/participant-data-dialog";
 import { RemoveParticipantButton } from "@/lib/admin-panel/tournaments/remove-participant-button";
 import { api } from "@/trpc/server";
 import type {
@@ -18,6 +19,7 @@ import type {
   TournamentParticipant,
   TournamentStage,
 } from "@prisma/client";
+import { getLocale } from "next-intl/server";
 import Link from "next/link";
 
 type TournamentParticipantsProps = {
@@ -35,10 +37,15 @@ type ParticipantWithGroups = TournamentParticipant & {
 export async function TournamentParticipants({
   tournamentId,
 }: TournamentParticipantsProps) {
-  const participants = (await api.tournaments.participants.list({
-    tournamentId,
-    includeUser: true,
-  })) as ParticipantWithGroups[];
+  const locale = await getLocale();
+
+  const [participants, registrationFields] = await Promise.all([
+    api.tournaments.participants.list({
+      tournamentId,
+      includeUser: true,
+    }) as Promise<ParticipantWithGroups[]>,
+    api.tournaments.registrationFields.list({ tournamentId }),
+  ]);
 
   return (
     <Card>
@@ -55,57 +62,76 @@ export async function TournamentParticipants({
                 <TableHead className="max-w-[200px]">Groups</TableHead>
                 <TableHead>Registration Date</TableHead>
                 <TableHead>Has user account</TableHead>
+                <TableHead>Data</TableHead>
                 <TableHead>Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {participants.map((participant) => (
-                <TableRow key={participant.id}>
-                  <TableCell>{participant.nickname}</TableCell>
-                  <TableCell>
-                    <Badge variant="outline">{participant.status}</Badge>
-                  </TableCell>
-                  <TableCell className="max-w-[100px]">
-                    <div className="flex flex-wrap gap-1 overflow-y-auto">
-                      {participant.TournamentGroupParticipant.length > 0 ? (
-                        participant.TournamentGroupParticipant.map(
-                          (groupParticipant) => (
-                            <Link
-                              key={groupParticipant.id}
-                              href={`/admin/tournaments/groups/${groupParticipant.tournamentGroup.id}`}
-                            >
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                className="text-xs"
+              {participants.map((participant) => {
+                const data =
+                  participant.registrationData &&
+                  typeof participant.registrationData === "object" &&
+                  !Array.isArray(participant.registrationData)
+                    ? (participant.registrationData as Record<string, unknown>)
+                    : {};
+
+                return (
+                  <TableRow key={participant.id}>
+                    <TableCell>{participant.nickname}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline">{participant.status}</Badge>
+                    </TableCell>
+                    <TableCell className="max-w-[100px]">
+                      <div className="flex flex-wrap gap-1 overflow-y-auto">
+                        {participant.TournamentGroupParticipant.length > 0 ? (
+                          participant.TournamentGroupParticipant.map(
+                            (groupParticipant) => (
+                              <Link
+                                key={groupParticipant.id}
+                                href={`/admin/tournaments/groups/${groupParticipant.tournamentGroup.id}`}
                               >
-                                {groupParticipant.tournamentGroup.name}
-                              </Button>
-                            </Link>
-                          ),
-                        )
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  className="text-xs"
+                                >
+                                  {groupParticipant.tournamentGroup.name}
+                                </Button>
+                              </Link>
+                            ),
+                          )
+                        ) : (
+                          <Badge variant="secondary">No groups assigned</Badge>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {new Date(
+                        participant.registrationDate,
+                      ).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell>
+                      {participant.userId ? (
+                        <Badge variant="outline">Yes</Badge>
                       ) : (
-                        <Badge variant="secondary">No groups assigned</Badge>
+                        <Badge variant="secondary">No</Badge>
                       )}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    {new Date(
-                      participant.registrationDate,
-                    ).toLocaleDateString()}
-                  </TableCell>
-                  <TableCell>
-                    {participant.userId ? (
-                      <Badge variant="outline">Yes</Badge>
-                    ) : (
-                      <Badge variant="secondary">No</Badge>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <RemoveParticipantButton participantId={participant.id} />
-                  </TableCell>
-                </TableRow>
-              ))}
+                    </TableCell>
+
+                    <TableCell>
+                      <ParticipantDataDialog
+                        participantId={participant.id}
+                        registrationData={data}
+                        registrationFields={registrationFields}
+                        locale={locale}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <RemoveParticipantButton participantId={participant.id} />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </ScrollArea>

--- a/src/lib/admin-panel/tournaments/tournament-participants.tsx
+++ b/src/lib/admin-panel/tournaments/tournament-participants.tsx
@@ -68,7 +68,7 @@ export async function TournamentParticipants({
             </TableHeader>
             <TableBody>
               {participants.map((participant) => {
-                const data =
+                const participantRegData =
                   participant.registrationData &&
                   typeof participant.registrationData === "object" &&
                   !Array.isArray(participant.registrationData)
@@ -121,7 +121,7 @@ export async function TournamentParticipants({
                     <TableCell>
                       <ParticipantDataDialog
                         participantId={participant.id}
-                        registrationData={data}
+                        registrationData={participantRegData}
                         registrationFields={registrationFields}
                         locale={locale}
                       />

--- a/src/lib/admin-panel/tournaments/tournament-sections.tsx
+++ b/src/lib/admin-panel/tournaments/tournament-sections.tsx
@@ -1,18 +1,19 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { api } from "@/trpc/react";
-import { toast } from "sonner";
-import { useTranslations } from "next-intl";
+import { Accordion } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { ErrorToast } from "@/components/ui/error-toast-content";
-import { Accordion } from "@/components/ui/accordion";
 import { specialTournamentSectionSlugs } from "@/lib/tournaments/section-constants";
-import type { SectionWithTranslations } from "./sections/tournament-section-types";
+import { api } from "@/trpc/react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { TournamentRegistrationSectionCard } from "./sections/registration/tournament-registration-section-card";
 import { TournamentSectionCard } from "./sections/tournament-section-card";
+import { TournamentSectionDialog } from "./sections/tournament-section-dialog";
+import type { SectionWithTranslations } from "./sections/tournament-section-types";
 import { TournamentSpecialSectionCard } from "./sections/tournament-special-section-card";
 import { TournamentSpecialSectionDialog } from "./sections/tournament-special-section-dialog";
-import { TournamentSectionDialog } from "./sections/tournament-section-dialog";
 
 export function TournamentSections({ tournamentId }: { tournamentId: string }) {
   const t = useTranslations("admin.tournaments.sections");
@@ -99,9 +100,12 @@ export function TournamentSections({ tournamentId }: { tournamentId: string }) {
       {hasSections && (
         <Accordion type="multiple">
           {ordered.map((section, index) => {
-            const Card = specialTournamentSectionSlugs.has(section.slug)
-              ? TournamentSpecialSectionCard
-              : TournamentSectionCard;
+            const Card =
+              section.slug === "registration"
+                ? TournamentRegistrationSectionCard
+                : specialTournamentSectionSlugs.has(section.slug)
+                  ? TournamentSpecialSectionCard
+                  : TournamentSectionCard;
 
             return (
               <Card

--- a/src/lib/repositories/tournamentParticipantRepository.ts
+++ b/src/lib/repositories/tournamentParticipantRepository.ts
@@ -32,6 +32,7 @@ export const tournamentParticipantRepository = {
     tournamentId: string,
     userId: string,
     nickname: string,
+    registrationData: Record<string, string | number | boolean> = {},
   ) {
     return db.tournamentParticipant.create({
       data: {
@@ -39,6 +40,7 @@ export const tournamentParticipantRepository = {
         userId,
         nickname,
         status: "REGISTERED",
+        registrationData,
       },
     });
   },
@@ -46,6 +48,16 @@ export const tournamentParticipantRepository = {
   async deleteByUserAndTournament(userId: string, tournamentId: string) {
     return db.tournamentParticipant.deleteMany({
       where: { userId, tournamentId },
+    });
+  },
+
+  async updateRegistrationData(
+    participantId: string,
+    registrationData: Record<string, string | number | boolean>,
+  ) {
+    return db.tournamentParticipant.update({
+      where: { id: participantId },
+      data: { registrationData },
     });
   },
 

--- a/src/lib/repositories/tournamentRegistrationFieldRepository.ts
+++ b/src/lib/repositories/tournamentRegistrationFieldRepository.ts
@@ -1,0 +1,80 @@
+import { db } from "@/server/db";
+import type { RegistrationFieldType } from "@prisma/client";
+
+export const tournamentRegistrationFieldRepository = {
+  async list(tournamentId: string) {
+    return db.tournamentRegistrationField.findMany({
+      where: { tournamentId },
+      orderBy: { displayOrder: "asc" },
+      include: { translations: true },
+    });
+  },
+
+  async create(data: {
+    tournamentId: string;
+    translations: { locale: string; label: string }[];
+    type: RegistrationFieldType;
+    required: boolean;
+    displayOrder?: number;
+  }) {
+    const { translations, ...rest } = data;
+    return db.tournamentRegistrationField.create({
+      data: {
+        ...rest,
+        translations: { create: translations },
+      },
+      include: { translations: true },
+    });
+  },
+
+  async update(
+    id: string,
+    data: {
+      translations?: { locale: string; label: string }[];
+      type?: RegistrationFieldType;
+      required?: boolean;
+    },
+  ) {
+    const { translations, ...rest } = data;
+
+    if (translations?.length) {
+      await db.$transaction(
+        translations.map(({ locale, label }) =>
+          db.tournamentRegistrationFieldTranslation.upsert({
+            where: { fieldId_locale: { fieldId: id, locale } },
+            update: { label },
+            create: { fieldId: id, locale, label },
+          }),
+        ),
+      );
+    }
+
+    if (Object.keys(rest).length) {
+      return db.tournamentRegistrationField.update({
+        where: { id },
+        data: rest,
+        include: { translations: true },
+      });
+    }
+
+    return db.tournamentRegistrationField.findUniqueOrThrow({
+      where: { id },
+      include: { translations: true },
+    });
+  },
+
+  async delete(id: string) {
+    return db.tournamentRegistrationField.delete({ where: { id } });
+  },
+
+  async reorder(updates: { id: string; displayOrder: number }[]) {
+    return db.$transaction(
+      updates.map(({ id, displayOrder }) =>
+        db.tournamentRegistrationField.update({
+          where: { id },
+          data: { displayOrder },
+        }),
+      ),
+    );
+  },
+};

--- a/src/lib/tournaments/section-constants.ts
+++ b/src/lib/tournaments/section-constants.ts
@@ -12,6 +12,7 @@ export const predefinedTournamentSections = [
 ] as const;
 
 export const specialTournamentSectionSlugs = new Set([
+  "registration",
   "calendar",
   "groups",
   "matches",

--- a/src/server/api/tournament.ts
+++ b/src/server/api/tournament.ts
@@ -7,6 +7,7 @@ import { tournamentGroupRepository } from "@/lib/repositories/tournamentGroupRep
 import { tournamentMatchModeRepository } from "@/lib/repositories/tournamentMatchModeRepository";
 import { tournamentMatchRepository } from "@/lib/repositories/tournamentMatchRepository";
 import { tournamentParticipantRepository } from "@/lib/repositories/tournamentParticipantRepository";
+import { tournamentRegistrationFieldRepository } from "@/lib/repositories/tournamentRegistrationFieldRepository";
 import { tournamentRepository } from "@/lib/repositories/tournamentRepository";
 import { tournamentSectionRepository } from "@/lib/repositories/tournamentSectionRepository";
 import { tournamentSeriesRepository } from "@/lib/repositories/tournamentSeriesRepository";
@@ -22,7 +23,11 @@ import type {
   TournamentParticipant,
   TournamentSeries,
 } from "@prisma/client";
-import { MatchStatus, TournamentMatchModeType } from "@prisma/client";
+import {
+  MatchStatus,
+  RegistrationFieldType,
+  TournamentMatchModeType,
+} from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
@@ -261,7 +266,14 @@ export const tournamentRouter = createTRPCRouter({
       }),
 
     register: protectedProcedure
-      .input(z.object({ tournamentId: z.string() }))
+      .input(
+        z.object({
+          tournamentId: z.string(),
+          formData: z
+            .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+            .optional(),
+        }),
+      )
       .mutation(async ({ input, ctx }) => {
         const userId = ctx.session.user.id;
         const nickname = ctx.session.user.name!;
@@ -276,10 +288,73 @@ export const tournamentRouter = createTRPCRouter({
           throw new TRPCError({ code: "CONFLICT" });
         }
 
+        const fields = await tournamentRegistrationFieldRepository.list(
+          input.tournamentId,
+        );
+
+        const validFieldIds = new Set(fields.map((f) => f.id));
+
+        for (const [key, val] of Object.entries(input.formData ?? {})) {
+          if (!validFieldIds.has(key)) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `Unknown field: ${key}`,
+            });
+          }
+
+          const field = fields.find((f) => f.id === key)!;
+
+          if (field.type === "NUMBER" && typeof val !== "number") {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `Field ${key} must be a number`,
+            });
+          }
+
+          if (field.type === "BOOLEAN" && typeof val !== "boolean") {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `Field ${key} must be a boolean`,
+            });
+          }
+
+          if (
+            field.type === "STRING" &&
+            (typeof val !== "string" || val.length > 60)
+          ) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `Field ${key} must be a string of at most 60 characters`,
+            });
+          }
+        }
+
+        const missingRequired = fields
+          .filter((f) => f.required)
+          .filter((f) => {
+            const val = input.formData?.[f.id];
+            return val === undefined || val === null || val === "";
+          });
+
+        if (missingRequired.length > 0) {
+          throw new TRPCError({
+            code: "UNPROCESSABLE_CONTENT",
+            message: `Missing required fields: ${missingRequired
+              .map(
+                (f) =>
+                  f.translations[0]?.label ??
+                  f.translations.find((t) => t.locale === "en")?.label ??
+                  f.id,
+              )
+              .join(", ")}`,
+          });
+        }
+
         return tournamentParticipantRepository.registerParticipant(
           input.tournamentId,
           userId,
           nickname,
+          input.formData ?? {},
         );
       }),
 
@@ -287,6 +362,23 @@ export const tournamentRouter = createTRPCRouter({
       .input(z.object({ participantId: z.string() }))
       .mutation(async ({ input }) => {
         return tournamentParticipantRepository.deleteById(input.participantId);
+      }),
+
+    updateRegistrationData: adminProcedure
+      .input(
+        z.object({
+          participantId: z.string(),
+          registrationData: z.record(
+            z.string(),
+            z.union([z.string(), z.number(), z.boolean()]),
+          ),
+        }),
+      )
+      .mutation(async ({ input }) => {
+        return tournamentParticipantRepository.updateRegistrationData(
+          input.participantId,
+          input.registrationData,
+        );
       }),
   }),
 
@@ -676,6 +768,67 @@ export const tournamentRouter = createTRPCRouter({
       )
       .mutation(async ({ input }) => {
         return tournamentSectionRepository.reorderSections(input.updates);
+      }),
+  }),
+
+  registrationFields: createTRPCRouter({
+    list: publicProcedure
+      .input(z.object({ tournamentId: z.string() }))
+      .query(async ({ input }) => {
+        return tournamentRegistrationFieldRepository.list(input.tournamentId);
+      }),
+
+    create: adminProcedure
+      .input(
+        z.object({
+          tournamentId: z.string(),
+          translations: z.array(
+            z.object({ locale: z.string(), label: z.string().min(1) }),
+          ),
+          type: z.nativeEnum(RegistrationFieldType),
+          required: z.boolean(),
+          displayOrder: z.number().int().min(0).optional(),
+        }),
+      )
+      .mutation(async ({ input }) => {
+        return tournamentRegistrationFieldRepository.create(input);
+      }),
+
+    update: adminProcedure
+      .input(
+        z.object({
+          id: z.string(),
+          translations: z
+            .array(z.object({ locale: z.string(), label: z.string().min(1) }))
+            .optional(),
+          type: z.nativeEnum(RegistrationFieldType).optional(),
+          required: z.boolean().optional(),
+        }),
+      )
+      .mutation(async ({ input }) => {
+        const { id, ...data } = input;
+        return tournamentRegistrationFieldRepository.update(id, data);
+      }),
+
+    delete: adminProcedure
+      .input(z.object({ id: z.string() }))
+      .mutation(async ({ input }) => {
+        return tournamentRegistrationFieldRepository.delete(input.id);
+      }),
+
+    reorder: adminProcedure
+      .input(
+        z.object({
+          updates: z.array(
+            z.object({
+              id: z.string(),
+              displayOrder: z.number().int().min(0),
+            }),
+          ),
+        }),
+      )
+      .mutation(async ({ input }) => {
+        return tournamentRegistrationFieldRepository.reorder(input.updates);
       }),
   }),
 });

--- a/src/server/api/tournament.ts
+++ b/src/server/api/tournament.ts
@@ -333,7 +333,7 @@ export const tournamentRouter = createTRPCRouter({
           .filter((f) => f.required)
           .filter((f) => {
             const val = input.formData?.[f.id];
-            return val === undefined || val === null || val === "";
+            return val == null || val === "";
           });
 
         if (missingRequired.length > 0) {

--- a/src/server/api/tournament.ts
+++ b/src/server/api/tournament.ts
@@ -340,12 +340,7 @@ export const tournamentRouter = createTRPCRouter({
           throw new TRPCError({
             code: "UNPROCESSABLE_CONTENT",
             message: `Missing required fields: ${missingRequired
-              .map(
-                (f) =>
-                  f.translations[0]?.label ??
-                  f.translations.find((t) => t.locale === "en")?.label ??
-                  f.id,
-              )
+              .map((f) => f.translations[0]?.label)
               .join(", ")}`,
           });
         }


### PR DESCRIPTION
Adds option for additional fields to be filled by users when registering for tournament.

Admin panel changes:
- Registration page in Sections now include options for adding extra fields. They need a label, type and check whether they are a mandatory field. Mandatory fields must be filled, otherwise registration will fail.
- In tournament's players' view, admins can now see column, which has all the extra data the players input. This data can be modified as well.

Tournament registration page:
- All extra fields will now show as defined in tournament's registration section, in the admin panel. Fields have slight validation and limits - cannot extend 60 characters, numerical fields only accept numbers, and mandatory fields must be filled out for registration to be successful.

All data is saved in the database as one would expect. Extra field data is saved in TournamentParticipant table, under registrationFields. Labels for those fields are localised, and text should be provided in all supported languages when adding a new field, in the admin panel's tournament sections tab.

Note that this data is saved in JSON format, and there will not be a good way to actually use it. No functionality has been requested, other than viewing it. We could parse data and look for specific keys if really needed to, but it's not ideal, since it's error prone.