### PR TITLE
Feat/user profile page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -686,7 +686,6 @@
     }
   },
   "profile": {
-    "unnamed": "(no name)",
     "roles": {
       "title": "Roles",
       "expired": "expired",
@@ -697,7 +696,7 @@
       "remove_success": "Role removed.",
       "remove_role": "Remove role",
       "remove_confirm_title": "Remove role",
-      "remove_confirm_description": "Remove the \"{{role}}\" role? This action cannot be undone.",
+      "remove_confirm_description": "Remove the \"{role}\" role? This action cannot be undone.",
       "remove_confirm": "Remove",
       "remove_cancel": "Cancel"
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,6 +4,7 @@
     "home": "Home",
     "news": "News",
     "tournaments": "Tournaments",
+    "profile": "Profile",
     "admin": "Admin",
     "logged_in_as": "Logged in as",
     "logout": "Log out",
@@ -682,6 +683,45 @@
       "group": "Group",
       "player": "Player",
       "search_players_or_group": "Search player or group"
+    }
+  },
+  "profile": {
+    "unnamed": "(no name)",
+    "roles": {
+      "title": "Roles",
+      "expired": "expired",
+      "none": "No roles assigned.",
+      "add_role": "Add role",
+      "add_role_placeholder": "Select a role...",
+      "assign_success": "Role assigned.",
+      "remove_success": "Role removed.",
+      "remove_role": "Remove role",
+      "remove_confirm_title": "Remove role",
+      "remove_confirm_description": "Remove the \"{{role}}\" role? This action cannot be undone.",
+      "remove_confirm": "Remove",
+      "remove_cancel": "Cancel"
+    },
+    "aoe2companion": {
+      "title": "AoE2Companion",
+      "none": "No AoE2Companion profile linked.",
+      "placeholder": "https://aoe2companion.com/players/...",
+      "save_success": "AoE2Companion link saved."
+    },
+    "tournaments": {
+      "title": "Tournament History",
+      "tournament": "Tournament",
+      "nickname": "Nickname",
+      "status": "Status",
+      "registered": "Registered",
+      "none": "No tournament participations."
+    },
+    "admin_note": {
+      "title": "Admin note",
+      "none": "No note.",
+      "placeholder": "Internal note about this user...",
+      "save": "Save",
+      "cancel": "Cancel",
+      "save_success": "Note saved."
     }
   }
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -696,7 +696,7 @@
       "remove_success": "Rola została usunięta.",
       "remove_role": "Usuń rolę",
       "remove_confirm_title": "Usuń rolę",
-      "remove_confirm_description": "Usunąć rolę \"{{role}}\"? Tej operacji nie można cofnąć.",
+      "remove_confirm_description": "Usunąć rolę \"{role}\"? Tej operacji nie można cofnąć.",
       "remove_confirm": "Usuń",
       "remove_cancel": "Anuluj"
     },

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -4,6 +4,7 @@
     "home": "Główna",
     "news": "Wiadomości",
     "tournaments": "Turnieje",
+    "profile": "Profil",
     "admin": "Admin",
     "logged_in_as": "Zalogowano jako",
     "logout": "Wyloguj",
@@ -682,6 +683,44 @@
       "group": "Grupa",
       "player": "Gracz",
       "search_players_or_group": "Szukaj gracza lub grupy"
+    }
+  },
+  "profile": {
+    "roles": {
+      "title": "Role",
+      "expired": "wygasła",
+      "none": "Brak przypisanych ról.",
+      "add_role": "Dodaj rolę",
+      "add_role_placeholder": "Wybierz rolę...",
+      "assign_success": "Rola została przypisana.",
+      "remove_success": "Rola została usunięta.",
+      "remove_role": "Usuń rolę",
+      "remove_confirm_title": "Usuń rolę",
+      "remove_confirm_description": "Usunąć rolę \"{{role}}\"? Tej operacji nie można cofnąć.",
+      "remove_confirm": "Usuń",
+      "remove_cancel": "Anuluj"
+    },
+    "aoe2companion": {
+      "title": "AoE2Companion",
+      "none": "Brak powiązanego profilu AoE2Companion.",
+      "placeholder": "https://aoe2companion.com/players/...",
+      "save_success": "Link AoE2Companion został zapisany."
+    },
+    "tournaments": {
+      "title": "Historia turniejów",
+      "tournament": "Turniej",
+      "nickname": "Nick",
+      "status": "Status",
+      "registered": "Data rejestracji",
+      "none": "Brak udziałów w turniejach."
+    },
+    "admin_note": {
+      "title": "Notatka admina",
+      "none": "Brak notatki.",
+      "placeholder": "Wewnętrzna notatka o użytkowniku...",
+      "save": "Zapisz",
+      "cancel": "Anuluj",
+      "save_success": "Notatka została zapisana."
     }
   }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -2,8 +2,8 @@
  * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially useful
  * for Docker builds.
  */
-import "./src/env.js";
 import createNextIntlPlugin from "next-intl/plugin";
+import "./src/env.js";
 
 /** @type {import("next").NextConfig} */
 const config = {};

--- a/prisma/migrations/20260525213656_add_aoe2companion_url/migration.sql
+++ b/prisma/migrations/20260525213656_add_aoe2companion_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "aoe2companionUrl" TEXT;

--- a/prisma/migrations/20260526203238_add_player_number_and_match_number/migration.sql
+++ b/prisma/migrations/20260526203238_add_player_number_and_match_number/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[matchNumber]` on the table `TournamentMatch` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[playerNumber]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "TournamentMatch" ADD COLUMN     "matchNumber" SERIAL NOT NULL;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "playerNumber" SERIAL NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TournamentMatch_matchNumber_key" ON "TournamentMatch"("matchNumber");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_playerNumber_key" ON "User"("playerNumber");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model Session {
 
 model User {
   id                    String                  @id @default(cuid())
+  playerNumber          Int                     @unique @default(autoincrement())
   name                  String?
   email                 String?                 @unique
   emailVerified         DateTime?
@@ -380,6 +381,7 @@ model TournamentGroupParticipant {
 
 model TournamentMatch {
   id                         String                       @id @default(cuid())
+  matchNumber                Int                          @unique @default(autoincrement())
   groupId                    String?
   matchDate                  DateTime?
   civDraftKey                String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model User {
   image                 String?
   color                 String?
   adminComment          String?
+  aoe2companionUrl      String?
   accounts              Account[]
   sessions              Session[]
   TournamentMatchStream TournamentMatchStream[]

--- a/src/app/(app)/players/[playerNumber]/page.tsx
+++ b/src/app/(app)/players/[playerNumber]/page.tsx
@@ -2,7 +2,7 @@ import { ProfileAdminNoteSection } from "@/components/profile/profile-admin-note
 import { ProfileAoe2CompanionSection } from "@/components/profile/profile-aoe2companion-section";
 import { ProfileRolesSection } from "@/components/profile/profile-roles-section";
 import { ProfileTournamentHistorySection } from "@/components/profile/profile-tournament-history-section";
-import { auth } from "@/server/auth";
+import { getIsAdmin, getSession } from "@/lib/session";
 import { api } from "@/trpc/server";
 import { notFound } from "next/navigation";
 
@@ -15,15 +15,15 @@ export default async function PlayerProfilePage({
   const playerNumberInt = Number(playerNumber);
   if (!Number.isInteger(playerNumberInt) || playerNumberInt <= 0) notFound();
 
-  const [profile, session] = await Promise.all([
+  const [profile, isAdmin] = await Promise.all([
     api.users.getPublicProfile({ playerNumber: playerNumberInt }),
-    auth(),
+    getIsAdmin(),
   ]);
 
   if (!profile) notFound();
 
+  const session = await getSession();
   const isOwnProfile = session?.user?.id === profile.id;
-  const isAdmin = await api.users.isAdmin();
   const availableRoles = isAdmin ? await api.roles.list() : [];
 
   return (

--- a/src/app/(app)/players/[playerNumber]/page.tsx
+++ b/src/app/(app)/players/[playerNumber]/page.tsx
@@ -1,0 +1,62 @@
+import { ProfileAdminNoteSection } from "@/components/profile/profile-admin-note-section";
+import { ProfileAoe2CompanionSection } from "@/components/profile/profile-aoe2companion-section";
+import { ProfileRolesSection } from "@/components/profile/profile-roles-section";
+import { ProfileTournamentHistorySection } from "@/components/profile/profile-tournament-history-section";
+import { auth } from "@/server/auth";
+import { api } from "@/trpc/server";
+import { notFound } from "next/navigation";
+
+export default async function PlayerProfilePage({
+  params,
+}: {
+  params: Promise<{ playerNumber: string }>;
+}) {
+  const { playerNumber } = await params;
+  const playerNumberInt = Number(playerNumber);
+  if (!Number.isInteger(playerNumberInt) || playerNumberInt <= 0) notFound();
+
+  const [profile, session] = await Promise.all([
+    api.users.getPublicProfile({ playerNumber: playerNumberInt }),
+    auth(),
+  ]);
+
+  if (!profile) notFound();
+
+  const isOwnProfile = session?.user?.id === profile.id;
+  const isAdmin = await api.users.isAdmin();
+  const availableRoles = isAdmin ? await api.roles.list() : [];
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-24">
+      <h1 className="text-foreground mb-8 text-3xl font-bold">
+        {profile.name}
+      </h1>
+
+      <div className="space-y-6">
+        <ProfileRolesSection
+          userId={profile.id}
+          currentUserId={session?.user?.id ?? ""}
+          currentRoles={profile.userRoles}
+          availableRoles={availableRoles}
+          isAdmin={isAdmin}
+        />
+
+        <ProfileAoe2CompanionSection
+          currentUrl={profile.aoe2companionUrl}
+          isEditable={isOwnProfile}
+        />
+
+        {isAdmin && (
+          <ProfileAdminNoteSection
+            userId={profile.id}
+            currentNote={profile.adminComment}
+          />
+        )}
+
+        <ProfileTournamentHistorySection
+          participants={profile.TournamentParticipant}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,7 +1,3 @@
-import { ProfileAdminNoteSection } from "@/components/profile/profile-admin-note-section";
-import { ProfileAoe2CompanionSection } from "@/components/profile/profile-aoe2companion-section";
-import { ProfileRolesSection } from "@/components/profile/profile-roles-section";
-import { ProfileTournamentHistorySection } from "@/components/profile/profile-tournament-history-section";
 import { auth } from "@/server/auth";
 import { api } from "@/trpc/server";
 import { redirect } from "next/navigation";
@@ -15,40 +11,5 @@ export default async function ProfilePage() {
   const profile = await api.users.getOwnProfile();
   if (!profile) redirect("/");
 
-  const isAdmin = await api.users.isAdmin();
-  const availableRoles = isAdmin ? await api.roles.list() : [];
-
-  return (
-    <div className="mx-auto max-w-3xl px-4 py-24">
-      <h1 className="text-foreground mb-8 text-3xl font-bold">
-        {profile.name}
-      </h1>
-
-      <div className="space-y-6">
-        <ProfileRolesSection
-          userId={profile.id}
-          currentUserId={session.user.id}
-          currentRoles={profile.userRoles}
-          availableRoles={availableRoles}
-          isAdmin={isAdmin}
-        />
-
-        <ProfileAoe2CompanionSection
-          currentUrl={profile.aoe2companionUrl}
-          isEditable={true}
-        />
-
-        {isAdmin && (
-          <ProfileAdminNoteSection
-            userId={profile.id}
-            currentNote={profile.adminComment}
-          />
-        )}
-
-        <ProfileTournamentHistorySection
-          participants={profile.TournamentParticipant}
-        />
-      </div>
-    </div>
-  );
+  redirect(`/players/${profile.playerNumber}`);
 }

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,0 +1,54 @@
+import { ProfileAdminNoteSection } from "@/components/profile/profile-admin-note-section";
+import { ProfileAoe2CompanionSection } from "@/components/profile/profile-aoe2companion-section";
+import { ProfileRolesSection } from "@/components/profile/profile-roles-section";
+import { ProfileTournamentHistorySection } from "@/components/profile/profile-tournament-history-section";
+import { auth } from "@/server/auth";
+import { api } from "@/trpc/server";
+import { redirect } from "next/navigation";
+
+export default async function ProfilePage() {
+  const session = await auth();
+  if (!session) {
+    redirect("/api/auth/signin");
+  }
+
+  const profile = await api.users.getOwnProfile();
+  if (!profile) redirect("/");
+
+  const isAdmin = await api.users.isAdmin();
+  const availableRoles = isAdmin ? await api.roles.list() : [];
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-24">
+      <h1 className="text-foreground mb-8 text-3xl font-bold">
+        {profile.name}
+      </h1>
+
+      <div className="space-y-6">
+        <ProfileRolesSection
+          userId={profile.id}
+          currentUserId={session.user.id}
+          currentRoles={profile.userRoles}
+          availableRoles={availableRoles}
+          isAdmin={isAdmin}
+        />
+
+        <ProfileAoe2CompanionSection
+          currentUrl={profile.aoe2companionUrl}
+          isEditable={true}
+        />
+
+        {isAdmin && (
+          <ProfileAdminNoteSection
+            userId={profile.id}
+            currentNote={profile.adminComment}
+          />
+        )}
+
+        <ProfileTournamentHistorySection
+          participants={profile.TournamentParticipant}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/tournaments/[seriesSlug]/[urlKey]/groups/page.tsx
+++ b/src/app/(app)/tournaments/[seriesSlug]/[urlKey]/groups/page.tsx
@@ -35,6 +35,7 @@ export default async function TournamentGroupsPage({
       players: participants.map((p) => ({
         id: p.id,
         name: p.nickname,
+        playerNumber: p.user!.playerNumber,
       })),
     });
   }

--- a/src/app/(app)/tournaments/[seriesSlug]/[urlKey]/matches/[matchNumber]/page.tsx
+++ b/src/app/(app)/tournaments/[seriesSlug]/[urlKey]/matches/[matchNumber]/page.tsx
@@ -1,3 +1,4 @@
+import { PlayerLink } from "@/components/player-link";
 import { getDateFnsLocale } from "@/components/tournaments/calendar/locale-utils";
 import { getTournamentOrNotFound } from "@/lib/helpers/tournament-page-data";
 import { tournamentMatchRepository } from "@/lib/repositories/tournamentMatchRepository";
@@ -8,13 +9,13 @@ import { notFound } from "next/navigation";
 export default async function TournamentMatchPage({
   params,
 }: {
-  params: Promise<{ seriesSlug: string; urlKey: string; matchId: string }>;
+  params: Promise<{ seriesSlug: string; urlKey: string; matchNumber: string }>;
 }) {
-  const { seriesSlug, urlKey, matchId } = await params;
+  const { seriesSlug, urlKey, matchNumber } = await params;
 
   const [, match, locale] = await Promise.all([
     getTournamentOrNotFound(seriesSlug, urlKey),
-    tournamentMatchRepository.getTournamentMatchById(matchId),
+    tournamentMatchRepository.getTournamentMatchByNumber(Number(matchNumber)),
     getLocale(),
   ]);
 
@@ -27,17 +28,17 @@ export default async function TournamentMatchPage({
   const getSlotName = (slot: (typeof participants)[number]): string => {
     if (slot.participant)
       return slot.participant.nickname ?? slot.participant.user?.name ?? "?";
-
     if (slot.team) return slot.team.name;
-
     return "?";
   };
 
   const p1 = participants[0];
   const p2 = participants[1];
 
-  const player1 = p1 ? getSlotName(p1) : "TBD";
-  const player2 = p2 ? getSlotName(p2) : "TBD";
+  const player1Name = p1 ? getSlotName(p1) : "TBD";
+  const player2Name = p2 ? getSlotName(p2) : "TBD";
+  const player1Number = p1?.participant?.user?.playerNumber;
+  const player2Number = p2?.participant?.user?.playerNumber;
 
   const dateLabel = match.matchDate
     ? format(new Date(match.matchDate), "PPP p", { locale: dateFnsLocale })
@@ -48,7 +49,15 @@ export default async function TournamentMatchPage({
   return (
     <div className="panel space-y-4">
       <h1 className="text-2xl font-bold">
-        {player1} <span className="text-muted-foreground">vs</span> {player2}
+        <PlayerLink
+          name={player1Name}
+          playerNumber={player1Number}
+        />{" "}
+        <span className="text-muted-foreground">vs</span>{" "}
+        <PlayerLink
+          name={player2Name}
+          playerNumber={player2Number}
+        />
       </h1>
       <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
         <dt className="text-muted-foreground">Date</dt>

--- a/src/app/(app)/tournaments/[seriesSlug]/[urlKey]/players/page.tsx
+++ b/src/app/(app)/tournaments/[seriesSlug]/[urlKey]/players/page.tsx
@@ -14,7 +14,7 @@ export default async function TournamentPlayersPage({
   const tournamentParticipants =
     await tournamentParticipantRepository.getTournamentParticipants(
       tournament.id,
-      { includeUser: false },
+      { includeUser: true },
     );
 
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,9 +5,8 @@ import { Geist } from "next/font/google";
 
 import { Navigation } from "@/components/layout/navigation";
 import { ThemeCustomizer } from "@/components/layout/theme-customizer";
-import { auth } from "@/server/auth";
+import { getIsAdmin, getSession } from "@/lib/session";
 import { TRPCReactProvider } from "@/trpc/react";
-import { api } from "@/trpc/server";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 
@@ -26,8 +25,8 @@ export default async function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   const locale = await getLocale();
   const messages = await getMessages();
-  const session = await auth();
-  const isAdmin = session ? await api.users.isAdmin() : false;
+  const session = await getSession();
+  const isAdmin = session ? await getIsAdmin() : false;
 
   return (
     <html

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import Link from "next/link";
-import Image from "next/image";
-import { Button } from "@/components/ui";
-import type { Session } from "next-auth";
-import { useState } from "react";
-import { Menu, X } from "lucide-react";
-import { useTranslations } from "next-intl";
 import { LanguageSwitcher } from "@/components/layout/language-switcher";
+import { Button } from "@/components/ui";
+import { Menu, X } from "lucide-react";
+import type { Session } from "next-auth";
+import { useTranslations } from "next-intl";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
 
 interface NavigationProps {
   session: Session | null;
@@ -109,6 +109,16 @@ function DesktopNavigation({
         </Link>
       ))}
 
+      {session && (
+        <Link
+          href="/profile"
+          className={navLinkClass}
+        >
+          {t("profile")}
+          <div className={underlineClass} />
+        </Link>
+      )}
+
       {isAdmin && (
         <Link
           href="/admin"
@@ -189,6 +199,16 @@ function MobileMenu({
             {item.label}
           </Link>
         ))}
+
+        {session && (
+          <Link
+            href="/profile"
+            className="text-foreground/80 hover:text-accent hover:bg-accent/10 rounded-md px-4 py-2 text-base font-semibold transition-colors"
+            onClick={onClose}
+          >
+            {t("profile")}
+          </Link>
+        )}
 
         {isAdmin && (
           <Link

--- a/src/components/player-link.tsx
+++ b/src/components/player-link.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export function PlayerLink({
+  playerNumber,
+  name,
+}: {
+  playerNumber: number | undefined;
+  name: string;
+}) {
+  if (playerNumber === undefined) return <span>{name}</span>;
+  return (
+    <Link
+      href={`/players/${playerNumber}`}
+      className="hover:underline"
+    >
+      {name}
+    </Link>
+  );
+}

--- a/src/components/profile/profile-admin-note-section.tsx
+++ b/src/components/profile/profile-admin-note-section.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ErrorToast } from "@/components/ui/error-toast-content";
+import { Textarea } from "@/components/ui/textarea";
+import { api } from "@/trpc/react";
+import { Check, NotebookPen, Pencil, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface ProfileAdminNoteSectionProps {
+  userId: string;
+  currentNote: string | null;
+}
+
+export function ProfileAdminNoteSection({
+  userId,
+  currentNote,
+}: ProfileAdminNoteSectionProps) {
+  const t = useTranslations("profile.admin_note");
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(currentNote ?? "");
+
+  const { mutate, isPending } = api.users.updateAdminNote.useMutation({
+    onSuccess: () => {
+      toast.success(t("save_success"));
+      setEditing(false);
+      router.refresh();
+    },
+    onError: (err) => toast.error(<ErrorToast message={err.message} />),
+  });
+
+  const handleSave = () => {
+    mutate({ userId, note: value });
+  };
+
+  const handleCancel = () => {
+    setValue(currentNote ?? "");
+    setEditing(false);
+  };
+
+  return (
+    <Card className="border-amber-500/30 bg-amber-500/5">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between text-base">
+          <span className="flex items-center gap-2">
+            <NotebookPen className="h-4 w-4" />
+            {t("title")}
+          </span>
+          {!editing && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setEditing(true)}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {editing ? (
+          <div className="space-y-2">
+            <Textarea
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={t("placeholder")}
+              rows={3}
+              autoFocus
+            />
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={isPending}
+              >
+                <Check className="mr-1 h-3.5 w-3.5" />
+                {t("save")}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={handleCancel}
+                disabled={isPending}
+              >
+                <X className="mr-1 h-3.5 w-3.5" />
+                {t("cancel")}
+              </Button>
+            </div>
+          </div>
+        ) : currentNote ? (
+          <p className="text-sm whitespace-pre-wrap">{currentNote}</p>
+        ) : (
+          <p className="text-muted-foreground text-sm">{t("none")}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/profile-aoe2companion-section.tsx
+++ b/src/components/profile/profile-aoe2companion-section.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ErrorToast } from "@/components/ui/error-toast-content";
+import { Input } from "@/components/ui/input";
+import { api } from "@/trpc/react";
+import { Check, ExternalLink, Link2, Pencil, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface ProfileAoe2CompanionSectionProps {
+  currentUrl: string | null;
+  isEditable: boolean;
+}
+
+export function ProfileAoe2CompanionSection({
+  currentUrl,
+  isEditable,
+}: ProfileAoe2CompanionSectionProps) {
+  const t = useTranslations("profile.aoe2companion");
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(currentUrl ?? "");
+
+  const { mutate, isPending } = api.users.updateOwnAoe2CompanionUrl.useMutation(
+    {
+      onSuccess: () => {
+        toast.success(t("save_success"));
+        setEditing(false);
+        router.refresh();
+      },
+      onError: (err) => toast.error(<ErrorToast message={err.message} />),
+    },
+  );
+
+  const handleSave = () => {
+    mutate({ url: value });
+  };
+
+  const handleCancel = () => {
+    setValue(currentUrl ?? "");
+    setEditing(false);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between text-base">
+          <span className="flex items-center gap-2">
+            <Link2 className="h-4 w-4" />
+            {t("title")}
+          </span>
+          {isEditable && !editing && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setEditing(true)}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {editing ? (
+          <div className="flex items-center gap-2">
+            <Input
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={t("placeholder")}
+              className="flex-1"
+              autoFocus
+            />
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={isPending}
+            >
+              <Check className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleCancel}
+              disabled={isPending}
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        ) : currentUrl ? (
+          <a
+            href={currentUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent flex items-center gap-2 text-sm hover:underline"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            {currentUrl}
+          </a>
+        ) : (
+          <p className="text-muted-foreground text-sm">{t("none")}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/profile-roles-section.tsx
+++ b/src/components/profile/profile-roles-section.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { ErrorToast } from "@/components/ui/error-toast-content";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { api } from "@/trpc/react";
+import type { Role } from "@prisma/client";
+import { Plus, Shield, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface CurrentRole {
+  id: string;
+  expiresAt: Date | null;
+  role: { id: string; name: string; type: string };
+}
+
+interface ProfileRolesSectionProps {
+  userId: string;
+  currentUserId: string;
+  currentRoles: CurrentRole[];
+  availableRoles: Role[];
+  isAdmin: boolean;
+}
+
+export function ProfileRolesSection({
+  userId,
+  currentUserId,
+  currentRoles,
+  availableRoles,
+  isAdmin,
+}: ProfileRolesSectionProps) {
+  const t = useTranslations("profile.roles");
+  const router = useRouter();
+  const now = new Date();
+  const [selectedRoleId, setSelectedRoleId] = useState<string>("");
+
+  const assignedRoleIds = new Set(currentRoles.map((r) => r.role.id));
+  const unassignedRoles = availableRoles.filter(
+    (r) => !assignedRoleIds.has(r.id),
+  );
+
+  const { mutate: assignRole, isPending: isAssigning } =
+    api.roles.assignRole.useMutation({
+      onSuccess: () => {
+        toast.success(t("assign_success"));
+        setSelectedRoleId("");
+        router.refresh();
+      },
+      onError: (err) => toast.error(<ErrorToast message={err.message} />),
+    });
+
+  const { mutate: removeRole, isPending: isRemoving } =
+    api.roles.removeRole.useMutation({
+      onSuccess: () => {
+        toast.success(t("remove_success"));
+        router.refresh();
+      },
+      onError: (err) => toast.error(<ErrorToast message={err.message} />),
+    });
+
+  const handleAssign = () => {
+    if (!selectedRoleId) return;
+    assignRole({ userId, roleId: selectedRoleId });
+  };
+
+  const isOwnProfile = userId === currentUserId;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Shield className="h-4 w-4" />
+          {t("title")}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {currentRoles.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {currentRoles.map((ur) => {
+              const expired = ur.expiresAt != null && ur.expiresAt < now;
+              const isSelfAdminRole = isOwnProfile && ur.role.type === "ADMIN";
+              const canRemove = isAdmin && !isSelfAdminRole;
+
+              return (
+                <Badge
+                  key={ur.id}
+                  variant={expired ? "secondary" : "default"}
+                  className="flex items-center gap-1 text-sm"
+                >
+                  {ur.role.name}
+                  {expired && (
+                    <span className="opacity-60">({t("expired")})</span>
+                  )}
+                  {canRemove && (
+                    <ConfirmDialog
+                      trigger={
+                        <button
+                          disabled={isRemoving}
+                          className="ml-1 rounded hover:opacity-70"
+                          aria-label={t("remove_role")}
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      }
+                      title={t("remove_confirm_title")}
+                      description={t("remove_confirm_description", {
+                        role: ur.role.name,
+                      })}
+                      cancelLabel={t("remove_cancel")}
+                      confirmLabel={t("remove_confirm")}
+                      onConfirm={() =>
+                        removeRole({ userId, roleId: ur.role.id })
+                      }
+                    />
+                  )}
+                </Badge>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">{t("none")}</p>
+        )}
+
+        {isAdmin && unassignedRoles.length > 0 && (
+          <div className="flex items-center gap-2">
+            <Select
+              value={selectedRoleId}
+              onValueChange={setSelectedRoleId}
+            >
+              <SelectTrigger className="w-48">
+                <SelectValue placeholder={t("add_role_placeholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                {unassignedRoles.map((role) => (
+                  <SelectItem
+                    key={role.id}
+                    value={role.id}
+                  >
+                    {role.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              size="sm"
+              onClick={handleAssign}
+              disabled={!selectedRoleId || isAssigning}
+            >
+              <Plus className="mr-1 h-3.5 w-3.5" />
+              {t("add_role")}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/profile-tournament-history-section.tsx
+++ b/src/components/profile/profile-tournament-history-section.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { slugify } from "@/lib/utils";
+import { Trophy } from "lucide-react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+
+type TournamentParticipant = {
+  id: string;
+  nickname: string | null;
+  registrationDate: Date;
+  tournament: {
+    name: string;
+    urlKey: string;
+    status: string;
+    tournamentSeries: {
+      name: string;
+    };
+  };
+};
+
+interface ProfileTournamentHistorySectionProps {
+  participants: TournamentParticipant[];
+}
+
+export function ProfileTournamentHistorySection({
+  participants,
+}: ProfileTournamentHistorySectionProps) {
+  const t = useTranslations("profile.tournaments");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Trophy className="h-4 w-4" />
+          {t("title")}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {participants.length > 0 ? (
+          <div className="rounded border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("tournament")}</TableHead>
+                  <TableHead>{t("nickname")}</TableHead>
+                  <TableHead>{t("status")}</TableHead>
+                  <TableHead>{t("registered")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {participants.map((p) => {
+                  const seriesSlug = slugify(
+                    p.tournament.tournamentSeries.name,
+                  );
+                  const href = `/tournaments/${seriesSlug}/${p.tournament.urlKey}`;
+                  return (
+                    <TableRow key={p.id}>
+                      <TableCell>
+                        <Link
+                          href={href}
+                          className="text-accent font-medium hover:underline"
+                        >
+                          {p.tournament.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-sm">{p.nickname}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={
+                            p.tournament.status === "ACTIVE"
+                              ? "default"
+                              : "secondary"
+                          }
+                          className="text-xs"
+                        >
+                          {p.tournament.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-sm">
+                        {new Date(p.registrationDate).toLocaleDateString()}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">{t("none")}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/tournaments/calendar/hooks/use-calendar-data.ts
+++ b/src/components/tournaments/calendar/hooks/use-calendar-data.ts
@@ -10,6 +10,7 @@ import {
 
 export interface TournamentMatchRow {
   id: string;
+  matchNumber: number;
   matchDate: Date | null;
   status: "PENDING" | "SCHEDULED" | "COMPLETED" | "ADMIN_APPROVED";
   group: MatchRowGroup | null;
@@ -101,6 +102,7 @@ export function useCalendarData(rows: TournamentMatchRow[]): CalendarData {
 
       mapped.push({
         id: row.id,
+        matchNumber: row.matchNumber,
         groupId: row.group.id,
         date: row.matchDate,
         player1Id: p1.id,

--- a/src/components/tournaments/calendar/match-tile.tsx
+++ b/src/components/tournaments/calendar/match-tile.tsx
@@ -74,7 +74,7 @@ export function MatchTile({
     </>
   );
 
-  const sharedProps = {
+  const props = {
     className: "relative w-full rounded-md border px-2.5 py-1.5",
     style: sharedStyle,
     title: `${player1.nickname} vs ${player2.nickname} — ${group.name}`,
@@ -83,7 +83,7 @@ export function MatchTile({
   return (
     <Link
       href={href}
-      {...sharedProps}
+      {...props}
     >
       {content}
     </Link>

--- a/src/components/tournaments/calendar/scheduled-match-card.tsx
+++ b/src/components/tournaments/calendar/scheduled-match-card.tsx
@@ -54,7 +54,7 @@ export function ScheduledMatchCard({
         group={group}
         player1={player1}
         player2={player2}
-        href={`${matchUrlBase}/${match.id}`}
+        href={`${matchUrlBase}/${match.matchNumber}`}
       />
       {canAct && (
         <DropdownMenu>
@@ -72,6 +72,7 @@ export function ScheduledMatchCard({
               onClick={() => {
                 onReschedule({
                   id: match.id,
+                  matchNumber: match.matchNumber,
                   matchDate: match.date,
                   status: "SCHEDULED",
                   group: { id: group.id, name: group.name, color: group.color },
@@ -125,6 +126,7 @@ export function ScheduledMatchCard({
                       onClick={() => {
                         onCancel({
                           id: match.id,
+                          matchNumber: match.matchNumber,
                           matchDate: match.date,
                           status: "SCHEDULED",
                           group: null,

--- a/src/components/tournaments/calendar/types.ts
+++ b/src/components/tournaments/calendar/types.ts
@@ -17,6 +17,7 @@ export interface CalendarPlayer {
 
 export interface CalendarMatch {
   id: string;
+  matchNumber: number;
   groupId: string;
   date: Date;
   player1Id: string;

--- a/src/components/tournaments/calendar/week-view.tsx
+++ b/src/components/tournaments/calendar/week-view.tsx
@@ -89,7 +89,7 @@ export function WeekView({
                         group={group}
                         player1={p1}
                         player2={p2}
-                        href={`${matchUrlBase}/${m.id}`}
+                        href={`${matchUrlBase}/${m.matchNumber}`}
                       />
                     );
                   })}

--- a/src/components/tournaments/groups/GroupLeaderboardTable.tsx
+++ b/src/components/tournaments/groups/GroupLeaderboardTable.tsx
@@ -1,3 +1,4 @@
+import { PlayerLink } from "@/components/player-link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Table,
@@ -13,6 +14,7 @@ import type { GroupPageData } from "./types/types";
 interface LeaderboardPlayerStats {
   playerId: string;
   playerName: string;
+  playerNumber: number;
   matchesPlayed: number;
   matchesWon: number;
   matchesLost: number;
@@ -32,6 +34,7 @@ export function GroupLeaderboardTable({
     playerMap.set(player.id, {
       playerId: player.id,
       playerName: player.name,
+      playerNumber: player.playerNumber,
       matchesPlayed: 0,
       matchesWon: 0,
       matchesLost: 0,
@@ -86,7 +89,12 @@ export function GroupLeaderboardTable({
               return (
                 <TableRow key={p.playerId}>
                   <TableCell>{index + 1}</TableCell>
-                  <TableCell>{p.playerName}</TableCell>
+                  <TableCell>
+                    <PlayerLink
+                      playerNumber={p.playerNumber}
+                      name={p.playerName}
+                    />
+                  </TableCell>
                   <TableCell>{p.matchesPlayed} </TableCell>
                   <TableCell>{p.matchesWon}</TableCell>
                   <TableCell>{p.matchesLost}</TableCell>

--- a/src/components/tournaments/groups/types/types.ts
+++ b/src/components/tournaments/groups/types/types.ts
@@ -13,5 +13,6 @@ export interface GroupPageData {
   players: {
     id: string;
     name: string;
+    playerNumber: number;
   }[];
 }

--- a/src/components/tournaments/matches/match-list.tsx
+++ b/src/components/tournaments/matches/match-list.tsx
@@ -16,6 +16,7 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 export interface MatchListRow {
   id: string;
+  matchNumber: number;
   matchDate: Date | null;
   status: "PENDING" | "SCHEDULED" | "COMPLETED" | "ADMIN_APPROVED";
   group: { id: string; name: string; color: string | null } | null;
@@ -142,7 +143,7 @@ export function MatchList({ matches, matchUrlBase }: MatchListProps) {
             return (
               <Link
                 key={match.id}
-                href={`${matchUrlBase}/${match.id}`}
+                href={`${matchUrlBase}/${match.matchNumber}`}
                 className="hover:bg-muted/50 flex w-full items-center gap-4 px-4 py-3 text-left transition-colors"
               >
                 <span className="min-w-0 flex-1 font-medium">

--- a/src/components/tournaments/players/tournament-player-list.tsx
+++ b/src/components/tournaments/players/tournament-player-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PlayerLink } from "@/components/player-link";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -41,7 +42,12 @@ export function TournamentPlayerList({
       <TableBody>
         {tournamentParticipants.map((player) => (
           <TableRow key={player.id}>
-            <TableCell className="font-medium">{player.nickname}</TableCell>
+            <TableCell className="font-medium">
+              <PlayerLink
+                playerNumber={player.user?.playerNumber}
+                name={player.nickname}
+              />
+            </TableCell>
             <TableCell className="flex gap-1">
               {player.TournamentGroupParticipant.map((gp) => (
                 <Badge

--- a/src/lib/admin-panel/settings/users/users-list.tsx
+++ b/src/lib/admin-panel/settings/users/users-list.tsx
@@ -1,18 +1,5 @@
 "use client";
 
-import { useState } from "react";
-import { useTranslations } from "next-intl";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -23,24 +10,39 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Drawer,
   DrawerContent,
+  DrawerDescription,
   DrawerHeader,
   DrawerTitle,
-  DrawerDescription,
 } from "@/components/ui/drawer";
-import { Edit, Trash2, Eye } from "lucide-react";
-import { api } from "@/trpc/react";
-import { toast } from "sonner";
 import { ErrorToast } from "@/components/ui/error-toast-content";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { UserForm, type UserFormSchema } from "./user-form";
-import { UserDetailView } from "./user-detail-view";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { api } from "@/trpc/react";
 import type { User } from "@prisma/client";
+import { Edit, Eye, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "sonner";
+import { UserDetailView } from "./user-detail-view";
+import { UserForm, type UserFormSchema } from "./user-form";
 
 type UserWithCounts = {
   id: string;
+  playerNumber: number;
   name: string | null;
   email: string | null;
   emailVerified: Date | null;
@@ -202,7 +204,13 @@ export function UsersList() {
                                 style={{ backgroundColor: user.color }}
                               />
                             )}
-                            {user.name ?? "No Name"}
+                            <Link
+                              href={`/players/${user.playerNumber}`}
+                              className="hover:underline"
+                              target="_blank"
+                            >
+                              {user.name ?? "No Name"}
+                            </Link>
                           </div>
                         </TableCell>
                         <TableCell className="max-w-xs truncate">

--- a/src/lib/admin-panel/settings/users/users-list.tsx
+++ b/src/lib/admin-panel/settings/users/users-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PlayerLink } from "@/components/player-link";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -34,34 +35,10 @@ import { api } from "@/trpc/react";
 import type { User } from "@prisma/client";
 import { Edit, Eye, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import Link from "next/link";
 import { useState } from "react";
 import { toast } from "sonner";
 import { UserDetailView } from "./user-detail-view";
 import { UserForm, type UserFormSchema } from "./user-form";
-
-type UserWithCounts = {
-  id: string;
-  playerNumber: number;
-  name: string | null;
-  email: string | null;
-  emailVerified: Date | null;
-  image: string | null;
-  color: string | null;
-  adminComment: string | null;
-  userRoles: Array<{
-    role: {
-      id: string;
-      name: string;
-      type: string;
-    };
-  }>;
-  _count: {
-    userRoles: number;
-    TournamentParticipant: number;
-    userStreams: number;
-  };
-};
 
 export function UsersList() {
   const t = useTranslations("admin.settings.users");
@@ -194,7 +171,7 @@ export function UsersList() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {users.map((user: UserWithCounts) => (
+                    {users.map((user) => (
                       <TableRow key={user.id}>
                         <TableCell className="font-medium">
                           <div className="flex items-center gap-2">
@@ -204,13 +181,11 @@ export function UsersList() {
                                 style={{ backgroundColor: user.color }}
                               />
                             )}
-                            <Link
-                              href={`/players/${user.playerNumber}`}
-                              className="hover:underline"
-                              target="_blank"
-                            >
-                              {user.name ?? "No Name"}
-                            </Link>
+                            <PlayerLink
+                              playerNumber={user.playerNumber}
+                              name={user.name!}
+                              key={user.id}
+                            ></PlayerLink>
                           </div>
                         </TableCell>
                         <TableCell className="max-w-xs truncate">

--- a/src/lib/repositories/tournamentMatchRepository.ts
+++ b/src/lib/repositories/tournamentMatchRepository.ts
@@ -215,6 +215,55 @@ export const tournamentMatchRepository = {
     });
   },
 
+  async getTournamentMatchByNumber(matchNumber: number) {
+    return db.tournamentMatch.findUnique({
+      where: { matchNumber },
+      include: {
+        TournamentMatchParticipant: {
+          include: {
+            participant: {
+              include: {
+                user: true,
+                team: true,
+              },
+            },
+            team: {
+              include: {
+                TournamentParticipant: {
+                  include: {
+                    user: true,
+                  },
+                },
+              },
+            },
+            gameParticipants: true,
+          },
+        },
+        Game: {
+          include: {
+            map: true,
+            participants: {
+              include: {
+                civ: true,
+                matchParticipant: true,
+              },
+            },
+          },
+        },
+        group: {
+          include: {
+            stage: {
+              include: {
+                tournament: true,
+              },
+            },
+          },
+        },
+        TournamentMatchMode: true,
+      },
+    });
+  },
+
   async getMatchesByGroupId(groupId: string) {
     return db.tournamentMatch.findMany({
       where: { groupId },

--- a/src/lib/repositories/usersRepository.ts
+++ b/src/lib/repositories/usersRepository.ts
@@ -46,6 +46,52 @@ export const usersRepository = {
     });
   },
 
+  async getOwnProfile(userId: string) {
+    return db.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        name: true,
+        aoe2companionUrl: true,
+        adminComment: true,
+        userRoles: {
+          select: {
+            id: true,
+            assignedAt: true,
+            expiresAt: true,
+            role: {
+              select: {
+                id: true,
+                name: true,
+                type: true,
+              },
+            },
+          },
+        },
+        TournamentParticipant: {
+          select: {
+            id: true,
+            nickname: true,
+            registrationDate: true,
+            status: true,
+            tournament: {
+              select: {
+                id: true,
+                name: true,
+                urlKey: true,
+                status: true,
+                tournamentSeries: {
+                  select: { name: true },
+                },
+              },
+            },
+          },
+          orderBy: { registrationDate: "desc" },
+        },
+      },
+    });
+  },
+
   async getUserWithDetails(id: string) {
     return db.user.findUnique({
       where: { id },
@@ -83,6 +129,22 @@ export const usersRepository = {
           },
         },
       },
+    });
+  },
+
+  async updateOwnAoe2CompanionUrl(userId: string, url: string | null) {
+    return db.user.update({
+      where: { id: userId },
+      data: { aoe2companionUrl: url },
+      select: { id: true, aoe2companionUrl: true },
+    });
+  },
+
+  async updateAdminNote(userId: string, note: string | null) {
+    return db.user.update({
+      where: { id: userId },
+      data: { adminComment: note },
+      select: { id: true, adminComment: true },
     });
   },
 

--- a/src/lib/repositories/usersRepository.ts
+++ b/src/lib/repositories/usersRepository.ts
@@ -5,6 +5,7 @@ export const usersRepository = {
     return db.user.findMany({
       select: {
         id: true,
+        playerNumber: true,
         name: true,
         email: true,
         emailVerified: true,
@@ -46,11 +47,12 @@ export const usersRepository = {
     });
   },
 
-  async getOwnProfile(userId: string) {
+  async getPublicProfile(playerNumber: number) {
     return db.user.findUnique({
-      where: { id: userId },
+      where: { playerNumber },
       select: {
         id: true,
+        playerNumber: true,
         name: true,
         aoe2companionUrl: true,
         adminComment: true,

--- a/src/lib/repositories/usersRepository.ts
+++ b/src/lib/repositories/usersRepository.ts
@@ -293,17 +293,10 @@ export const usersRepository = {
   },
 
   async isUserAdmin(userId: string) {
-    const user = await db.user.findUnique({
-      where: { id: userId },
-      select: {
-        userRoles: {
-          select: {
-            role: true,
-          },
-        },
-      },
+    const adminRole = await db.userRole.findFirst({
+      where: { userId, role: { type: "ADMIN" } },
+      select: { userId: true },
     });
-
-    return user?.userRoles.some((ur) => ur.role.type === "ADMIN") ?? false;
+    return adminRole !== null;
   },
 };

--- a/src/lib/repositories/usersRepository.ts
+++ b/src/lib/repositories/usersRepository.ts
@@ -12,6 +12,7 @@ export const usersRepository = {
         image: true,
         color: true,
         adminComment: true,
+        aoe2companionUrl: true,
         userRoles: {
           select: {
             role: {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,21 @@
+import { usersRepository } from "@/lib/repositories/usersRepository";
+import { auth } from "@/server/auth";
+import { cache } from "react";
+
+/**
+ * Per-request cached session. Calling this multiple times in the same RSC tree
+ * (e.g. layout + page) only hits the DB once.
+ */
+export const getSession = cache(() => auth());
+
+/**
+ * Per-request cached isAdmin check. Layout and page can both call this
+ * without triggering duplicate queries.
+ */
+export const getIsAdmin = cache(async () => {
+  const session = await getSession();
+
+  if (!session?.user?.id) return false;
+
+  return usersRepository.isUserAdmin(session.user.id);
+});

--- a/src/server/api/roles.ts
+++ b/src/server/api/roles.ts
@@ -1,6 +1,6 @@
-import { z } from "zod";
-import { createTRPCRouter, adminProcedure } from "@/server/api/trpc";
 import { rolesRepository } from "@/lib/repositories/rolesRepository";
+import { adminProcedure, createTRPCRouter } from "@/server/api/trpc";
+import { z } from "zod";
 
 const assignRoleSchema = z.object({
   userId: z.string(),
@@ -17,24 +17,8 @@ const updateRoleSchema = z.object({
 });
 
 export const rolesRouter = createTRPCRouter({
-  list: adminProcedure.query(async ({ ctx }) => {
-    const allRoles = await rolesRepository.getAllRoles();
-
-    // Check if current user is admin
-    if (!ctx.session?.user?.id) {
-      return allRoles.filter((role) => role.modAssignable);
-    }
-
-    const isUserAdmin = await rolesRepository.getUserRoles(ctx.session.user.id);
-    const hasAdminRole = isUserAdmin.some((ur) => ur.role.type === "ADMIN");
-
-    // If user is admin, show all roles
-    if (hasAdminRole) {
-      return allRoles;
-    }
-
-    // If user is moderator, only show roles that are modAssignable
-    return allRoles.filter((role) => role.modAssignable);
+  list: adminProcedure.query(async () => {
+    return rolesRepository.getAllRoles();
   }),
 
   getUserRoles: adminProcedure

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -11,9 +11,9 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
 import { ZodError } from "zod";
 
+import { getIsProductionEnv } from "@/lib/utils";
 import { auth } from "@/server/auth";
 import { db } from "@/server/db";
-import { getIsProductionEnv } from "@/lib/utils";
 
 // Simple in-memory cache for user roles (you might want to use Redis in production)
 const userRolesCache = new Map<
@@ -124,26 +124,12 @@ async function isUserAdmin(userId: string): Promise<boolean> {
     return cached.isAdmin;
   }
 
-  // Fetch fresh data from database
-  const userWithRoles = await db.user.findUnique({
-    where: { id: userId },
-    include: {
-      userRoles: {
-        include: {
-          role: true,
-        },
-      },
-    },
+  const adminRole = await db.userRole.findFirst({
+    where: { userId, role: { type: "ADMIN" } },
+    select: { userId: true },
   });
 
-  // Handle case where user is not found
-  if (!userWithRoles) {
-    throw new TRPCError({ code: "UNAUTHORIZED" });
-  }
-
-  const isAdmin = userWithRoles.userRoles.some(
-    (ur) => ur.role?.type === "ADMIN",
-  );
+  const isAdmin = adminRole !== null;
 
   // Cache the result
   userRolesCache.set(userId, { isAdmin, timestamp: now });

--- a/src/server/api/users.ts
+++ b/src/server/api/users.ts
@@ -1,10 +1,11 @@
-import { z } from "zod";
-import {
-  createTRPCRouter,
-  publicProcedure,
-  adminProcedure,
-} from "@/server/api/trpc";
 import { usersRepository } from "@/lib/repositories/usersRepository";
+import {
+  adminProcedure,
+  createTRPCRouter,
+  protectedProcedure,
+  publicProcedure,
+} from "@/server/api/trpc";
+import { z } from "zod";
 
 const updateUserSchema = z.object({
   name: z.string().min(1, "Name is required").optional(),
@@ -66,4 +67,27 @@ export const usersRouter = createTRPCRouter({
 
     return usersRepository.isUserAdmin(ctx.session.user.id);
   }),
+
+  getOwnProfile: protectedProcedure.query(async ({ ctx }) => {
+    return usersRepository.getOwnProfile(ctx.session.user.id);
+  }),
+
+  updateOwnAoe2CompanionUrl: protectedProcedure
+    .input(
+      z.object({
+        url: z.string().url("Invalid URL").optional().or(z.literal("")),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      return usersRepository.updateOwnAoe2CompanionUrl(
+        ctx.session.user.id,
+        input.url || null,
+      );
+    }),
+
+  updateAdminNote: adminProcedure
+    .input(z.object({ userId: z.string(), note: z.string() }))
+    .mutation(async ({ input }) => {
+      return usersRepository.updateAdminNote(input.userId, input.note || null);
+    }),
 });

--- a/src/server/api/users.ts
+++ b/src/server/api/users.ts
@@ -5,6 +5,7 @@ import {
   protectedProcedure,
   publicProcedure,
 } from "@/server/api/trpc";
+import { db } from "@/server/db";
 import { z } from "zod";
 
 const updateUserSchema = z.object({
@@ -24,6 +25,12 @@ export const usersRouter = createTRPCRouter({
     .input(z.object({ id: z.string() }))
     .query(async ({ input }) => {
       return usersRepository.getUserById(input.id);
+    }),
+
+  getPublicProfile: publicProcedure
+    .input(z.object({ playerNumber: z.number().int() }))
+    .query(async ({ input }) => {
+      return usersRepository.getPublicProfile(input.playerNumber);
     }),
 
   getWithDetails: adminProcedure
@@ -69,7 +76,10 @@ export const usersRouter = createTRPCRouter({
   }),
 
   getOwnProfile: protectedProcedure.query(async ({ ctx }) => {
-    return usersRepository.getOwnProfile(ctx.session.user.id);
+    return db.user.findUnique({
+      where: { id: ctx.session.user.id },
+      select: { id: true, playerNumber: true },
+    });
   }),
 
   updateOwnAoe2CompanionUrl: protectedProcedure
@@ -81,7 +91,7 @@ export const usersRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       return usersRepository.updateOwnAoe2CompanionUrl(
         ctx.session.user.id,
-        input.url || null,
+        input.url ?? null,
       );
     }),
 

--- a/tests/calendar-utils.test.ts
+++ b/tests/calendar-utils.test.ts
@@ -16,6 +16,7 @@ function makeMatch(date: Date, id = "m1"): CalendarMatch {
     date,
     player1Id: "p1",
     player2Id: "p2",
+    matchNumber: 1,
     status: CalendarMatchStatus.Scheduled,
   };
 }


### PR DESCRIPTION
Adds simple profile page with name, role specific content (admins can add notes, edit fields), basic info. 
TBD what's actually required, but good starting point.

- Matches and player profiles now use new fields [playerName] [matchNumber]. This is purely so we don't use super long randomly generated strings (user and match ids) in the URL.
- Can now go to any player profile, just by clicking on their name (in admin panel or tournament pages)